### PR TITLE
Pick random machine from the wait table.

### DIFF
--- a/cmd/metal-api/internal/datastore/machine.go
+++ b/cmd/metal-api/internal/datastore/machine.go
@@ -481,7 +481,7 @@ func (rs *RethinkStore) FindAvailableMachine(partitionid, sizeid string) (*metal
 		"state": map[string]string{
 			"value": string(metal.AvailableState),
 		},
-	})
+	}).Sample(1)
 
 	var available metal.Machines
 	err := rs.searchEntities(&q, &available)

--- a/test/rest/machines.rest
+++ b/test/rest/machines.rest
@@ -8,7 +8,7 @@ Authorization: Metal-Admin bfe5650d0149046959e7e49105134877906ebd6e1be0136dd6c51
 X-Date: 1985-04-12T23:20:50.52Z
 
 {
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "rackid": "Vagrant Rack 1",
   "hardware": {
     "cpu_cores": 1,
@@ -68,7 +68,7 @@ POST {{baseurl}}/register
 Content-Type: application/json
 
 {
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "rackid": "Vagrant Rack 1",
   "hardware": {
     "cpu_cores": 8,
@@ -107,7 +107,7 @@ Authorization: Metal-Admin bfe5650d0149046959e7e49105134877906ebd6e1be0136dd6c51
 X-Date: 1985-04-12T23:20:50.52Z
 
 {
-  "partition_id": "vagrant-lab"
+  "partition_id": "vagrant"
 }
 
 ### find all
@@ -130,16 +130,17 @@ X-Date: 1985-04-12T23:20:50.52Z
 
 {
   "description": "My first metal host",
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "hostname": "metal-test-1",
-  "imageid": "ubuntu-19.04",
+  "imageid": "ubuntu-19.10",
   "name": "Metal Host 1",
-  "projectid": "cada86ca-af5c-4358-b222-a2a09652f269",
+  "projectid": "00000000-0000-0000-0000-000000000001",
   "sizeid": "v1-small-x86",
   "ssh_pub_keys": [],
   "ips": [],
   "networks": [
-    {"networkid": "internet-vagrant-lab"}
+    {"networkid": "internet-vagrant"},
+    {"networkid": "9df96f13-054e-4686-b436-aa154b6318d4"}
   ]
 }
 
@@ -166,7 +167,7 @@ Content-Type: application/json
 {
   "uuid": "ae671b8b-a158-52c2-8c22-985ca0503873",
   "description": "My first metal host",
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "hostname": "metal-test-1",
   "imageid": "1",
   "name": "Metal Host 1",
@@ -223,7 +224,7 @@ POST {{baseurl}}/register
 Content-Type: application/json
 
 {
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "rackid": "Vagrant Rack 1",
   "hardware": {
     "cpu_cores": 1,

--- a/test/rest/networks.rest
+++ b/test/rest/networks.rest
@@ -13,7 +13,7 @@ Authorization: Metal-Admin bfe5650d0149046959e7e49105134877906ebd6e1be0136dd6c51
 X-Date: 1985-04-12T23:20:50.52Z
 
 {
-  "partitionid": "vagrant-lab"
+  "partitionid": "vagrant"
 }
 
 ### create project super network
@@ -24,11 +24,11 @@ Authorization: Metal-Admin ad24814d87cf57f35e1f075d02a7eb748d17536cbdff473c09be2
 X-Date: 1985-04-12T23:20:50.52Z
 
 {
-  "id": "tenant-super-network-vagrant-lab",
+  "id": "tenant-super-network-vagrant",
   "description": "Project Super Network",
   "name": "projects",
   "nat": false,
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "prefixes": [
     "10.0.0.0/16"
   ],
@@ -43,11 +43,11 @@ Authorization: Metal-Admin ad24814d87cf57f35e1f075d02a7eb748d17536cbdff473c09be2
 X-Date: 1985-04-12T23:20:50.52Z
 
 {
-  "id": "internet-vagrant-lab",
+  "id": "internet-vagrant",
   "description": "Internet in Vagrant",
   "name": "vagrant internet",
   "nat": false,
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "prefixes": [
     "185.24.0.0/16",
     "185.27.0.0/16"
@@ -63,12 +63,12 @@ Authorization: Metal-Admin ad24814d87cf57f35e1f075d02a7eb748d17536cbdff473c09be2
 X-Date: 1985-04-12T23:20:50.52Z
 
 {
-  "id": "underlay-vagrant-lab",
+  "id": "underlay-vagrant",
   "description": "Underlay in Vagrant",
   "name": "vagrant underlay",
   "nat": false,
   "underlay": true,
-  "partitionid": "vagrant-lab",
+  "partitionid": "vagrant",
   "vrf": 10000,
   "prefixes": [
     "10.1.0.0/24"
@@ -76,16 +76,16 @@ X-Date: 1985-04-12T23:20:50.52Z
   "privatesuper": false
 }
 
-### acquire network
-# @name acquireNetwork
-POST {{baseurl}}/acquire
+### allocate network
+# @name allocateNetwork
+POST {{baseurl}}/allocate
 Content-Type: application/json
 Authorization: Metal-Admin bfe5650d0149046959e7e49105134877906ebd6e1be0136dd6c51cb095d4ea8d
 X-Date: 1985-04-12T23:20:50.52Z
 
 {
-  "projectid": "cada86ca-af5c-4358-b222-a2a09652f269",
-  "partitionid": "vagrant-lab"
+  "projectid": "00000000-0000-0000-0000-000000000001",
+  "partitionid": "vagrant"
 }
 
 ### release network
@@ -98,7 +98,7 @@ X-Date: 1985-04-12T23:20:50.52Z
 
 ### delete network
 # @name deleteNetwork
-DELETE {{baseurl}}/tenant-super-network-vagrant-lab
+DELETE {{baseurl}}/tenant-super-network-vagrant
 Content-Type: application/json
 Authorization: Metal-Admin 60d4480107818d260233f835ff91ec85df194a2300b290e8aba4449246919d81
 X-Date: 1985-04-12T23:20:50.52Z


### PR DESCRIPTION
This should mitigate the effect a little that when multiple machine allocate requests occur at the same time "machine already allocated" is being returned.