### PR TITLE
Set VRF at switches before removing machine allocation.

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1523,6 +1523,12 @@ func (r machineResource) freeMachine(request *restful.Request, response *restful
 		}
 	}
 
+	sw, err := setVrfAtSwitches(r.ds, m, "")
+	utils.Logger(request).Sugar().Infow("set VRF at switch", "machineID", id, "error", err)
+	if checkError(request, response, utils.CurrentFuncName(), err) {
+		return
+	}
+
 	if m.Allocation != nil {
 		// if the machine is allocated, we free it in our database
 		err = r.releaseMachineNetworks(m, m.Allocation.MachineNetworks)
@@ -1545,12 +1551,6 @@ func (r machineResource) freeMachine(request *restful.Request, response *restful
 
 	// do the next steps in any case, so a client can call this function multiple times to
 	// fire of the needed events
-
-	sw, err := setVrfAtSwitches(r.ds, m, "")
-	utils.Logger(request).Sugar().Infow("set VRF at switch", "machineID", id, "error", err)
-	if checkError(request, response, utils.CurrentFuncName(), err) {
-		return
-	}
 
 	deleteEvent := metal.MachineEvent{Type: metal.DELETE, Old: m}
 	err = r.Publish(metal.TopicMachine.GetFQN(m.PartitionID), deleteEvent)

--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1523,8 +1523,18 @@ func (r machineResource) freeMachine(request *restful.Request, response *restful
 		}
 	}
 
+	// do the next steps in any case, so a client can call this function multiple times to
+	// fire the events
+
 	sw, err := setVrfAtSwitches(r.ds, m, "")
 	utils.Logger(request).Sugar().Infow("set VRF at switch", "machineID", id, "error", err)
+	if checkError(request, response, utils.CurrentFuncName(), err) {
+		return
+	}
+
+	deleteEvent := metal.MachineEvent{Type: metal.DELETE, Old: m}
+	err = r.Publish(metal.TopicMachine.GetFQN(m.PartitionID), deleteEvent)
+	utils.Logger(request).Sugar().Infow("published machine delete event", "machineID", id, "error", err)
 	if checkError(request, response, utils.CurrentFuncName(), err) {
 		return
 	}
@@ -1548,16 +1558,6 @@ func (r machineResource) freeMachine(request *restful.Request, response *restful
 		return
 	}
 	utils.Logger(request).Sugar().Infow("freed machine", "machineID", id)
-
-	// do the next steps in any case, so a client can call this function multiple times to
-	// fire of the needed events
-
-	deleteEvent := metal.MachineEvent{Type: metal.DELETE, Old: m}
-	err = r.Publish(metal.TopicMachine.GetFQN(m.PartitionID), deleteEvent)
-	utils.Logger(request).Sugar().Infow("published machine delete event", "machineID", id, "error", err)
-	if checkError(request, response, utils.CurrentFuncName(), err) {
-		return
-	}
 
 	switchEvent := metal.SwitchEvent{Type: metal.UPDATE, Machine: *m, Switches: sw}
 	err = r.Publish(metal.TopicSwitch.GetFQN(m.PartitionID), switchEvent)


### PR DESCRIPTION
This targets to mitigate the case that when machine free fails in between (after removing allocation from machine but before reconfiguring the switches). This does not resolve the issue of properly freeing a machine, but ensures that a machine cannot reboot back into the prior OS and being able to connect to the internet again. When the machine can reach the internet, user services on the machine can start running again as if nothing happened, which is dangerous.