### PR TITLE
Make machine liveliness a command, not an API endpoint.

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Lint
       uses: actions-contrib/golangci-lint@master
       with:

--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -1,4 +1,4 @@
-name: Build from master
+name: Build latest image
 
 on:
   push:

--- a/.github/workflows/tagged.yaml
+++ b/.github/workflows/tagged.yaml
@@ -14,12 +14,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+    - name: Branch name
+      run: echo running on branch ${GITHUB_REF##*/}
     - name: Lint
       uses: actions-contrib/golangci-lint@master
       with:
         args: run
-    - name: Branch name
-      run: echo running on branch ${GITHUB_REF##*/}
     - name: Build the Docker images
       run: |
         export GITHUB_TAG_NAME=${GITHUB_REF##*/}

--- a/.github/workflows/tagged.yaml
+++ b/.github/workflows/tagged.yaml
@@ -1,9 +1,12 @@
-name: Build and Test
+name: Build tagged image
 
 on:
   push:
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/tagged.yaml
+++ b/.github/workflows/tagged.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Branch name
       run: echo running on branch ${GITHUB_REF##*/}
     - name: Lint

--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1748,7 +1748,7 @@ func MachineLiveliness(ds *datastore.RethinkStore, logger *zap.SugaredLogger) er
 
 	metrics.ProvideLiveliness(liveliness)
 
-	logger.Info("machine liveliness evaluated", "alive", alive, "dead", dead, "unknown", unknown, "errors", errors)
+	logger.Infow("machine liveliness evaluated", "alive", alive, "dead", dead, "unknown", unknown, "errors", errors)
 
 	return nil
 }

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -107,12 +107,6 @@ type MachineNicExtended struct {
 	Neighbors MachineNicsExtended `json:"neighbors" description:"the neighbors visible to this network interface"`
 }
 
-type MachineLivelinessReport struct {
-	AliveCount   int `json:"alive_count" description:"the number of machines alive"`
-	DeadCount    int `json:"dead_count" description:"the number of dead machines"`
-	UnknownCount int `json:"unknown_count" description:"the number of machines with unknown liveliness"`
-}
-
 type MachineBIOS struct {
 	Version string `json:"version" modelDescription:"The bios version" description:"the bios version"`
 	Vendor  string `json:"vendor" description:"the bios vendor"`

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	nsq2 "github.com/nsqio/go-nsq"
+	"github.com/pkg/errors"
 
 	"github.com/metal-stack/metal-lib/jwt/grp"
 	"github.com/metal-stack/metal-lib/jwt/sec"
@@ -88,7 +89,7 @@ var initDatabase = &cobra.Command{
 	Short:   "initializes the database with all tables and indices",
 	Version: v.V.String(),
 	Run: func(cmd *cobra.Command, args []string) {
-		initializeDatabase()
+		initDataStore()
 	},
 }
 
@@ -96,13 +97,22 @@ var resurrectMachines = &cobra.Command{
 	Use:     "resurrect-machines",
 	Short:   "resurrect dead machines",
 	Version: v.V.String(),
-	Run: func(cmd *cobra.Command, args []string) {
-		resurrectDeadMachines()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return resurrectDeadMachines()
+	},
+}
+
+var machineLiveliness = &cobra.Command{
+	Use:     "machine-liveliness",
+	Short:   "evaluates whether machines are still alive or if they have died",
+	Version: v.V.String(),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return evaluateLiveliness()
 	},
 }
 
 func main() {
-	rootCmd.AddCommand(dumpSwagger, initDatabase, resurrectMachines)
+	rootCmd.AddCommand(dumpSwagger, initDatabase, resurrectMachines, machineLiveliness)
 	if err := rootCmd.Execute(); err != nil {
 		logger.Error("failed executing root command", "error", err)
 	}
@@ -294,7 +304,7 @@ func initDataStore() {
 	err := ds.Connect()
 
 	if err != nil {
-		logger.Errorw("cannot connect to db in root command metal-api/internal/main.initDatastore()", "error", err)
+		logger.Errorw("cannot connect to data store", "error", err)
 		panic(err)
 	}
 }
@@ -464,22 +474,31 @@ func dumpSwaggerJSON() {
 	fmt.Printf("%s\n", js)
 }
 
-func initializeDatabase() {
-	initDataStore()
-	logger.Info("Database initialized")
-}
-
-func resurrectDeadMachines() {
+func resurrectDeadMachines() error {
 	initDataStore()
 	initEventBus()
 	var p bus.Publisher
 	if nsqer != nil {
 		p = nsqer.Publisher
 	}
+
 	err := service.ResurrectMachines(ds, p, logger)
 	if err != nil {
-		logger.Errorw("unable to resurrect machines", "error", err)
+		return errors.Wrap(err, "unable to resurrect machines")
 	}
+
+	return nil
+}
+
+func evaluateLiveliness() error {
+	initDataStore()
+
+	err := service.MachineLiveliness(ds, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to evaluate machine liveliness")
+	}
+
+	return nil
 }
 
 func run() {

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -1522,30 +1522,6 @@
                 "updated"
             ]
         },
-        "v1.MachineLivelinessReport": {
-            "properties": {
-                "alive_count": {
-                    "description": "the number of machines alive",
-                    "format": "int32",
-                    "type": "integer"
-                },
-                "dead_count": {
-                    "description": "the number of dead machines",
-                    "format": "int32",
-                    "type": "integer"
-                },
-                "unknown_count": {
-                    "description": "the number of machines with unknown liveliness",
-                    "format": "int32",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "alive_count",
-                "dead_count",
-                "unknown_count"
-            ]
-        },
         "v1.MachineNetwork": {
             "description": "prefixes that are reachable within this network",
             "properties": {
@@ -3629,45 +3605,6 @@
                     }
                 },
                 "summary": "returns machines including the ipmi connection data",
-                "tags": [
-                    "machine"
-                ]
-            }
-        },
-        "/v1/machine/liveliness": {
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "checkMachineLiveliness",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/v1.EmptyBody"
-                        }
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v1.MachineLivelinessReport"
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "schema": {
-                            "$ref": "#/definitions/httperrors.HTTPErrorResponse"
-                        }
-                    }
-                },
-                "summary": "external trigger for evaluating machine liveliness",
                 "tags": [
                     "machine"
                 ]


### PR DESCRIPTION
References #12.

Closes #12.