### PR TITLE
Add log output when machine resurrection finished.

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1815,6 +1815,8 @@ func ResurrectMachines(ds *datastore.RethinkStore, publisher bus.Publisher, ipam
 		}
 	}
 
+	logger.Info("finished machine resurrection")
+
 	return nil
 }
 


### PR DESCRIPTION
It can look like machine resurrection stopped, when an error occurs... this just indicates that the algorithm continues.

Example of complete output now looks like:

```
k logs metal-api-resurrection-1584698400-9ztdg 
{"level":"info","time":"2020-03-20T10:00:08.094Z","caller":"datastore/rethinkdb.go:166","message":"Rethinkstore connected"}
{"level":"info","time":"2020-03-20T10:00:08.099Z","caller":"eventbus/nsq.go:43","message":"nsq connected","nsqd":"&{TCPAddress:fits.cloud:4150 HTTPEndpoint:nsqd:4151 TLS:0xc0000f7600 NSQ:0xc0000ce000}"}
{"level":"info","time":"2020-03-20T10:00:08.103Z","caller":"eventbus/nsq.go:67","message":"topic created","partition":"fel-wps101","topic":"fel-wps101-machine"}
{"level":"info","time":"2020-03-20T10:00:08.103Z","caller":"eventbus/nsq.go:67","message":"topic created","partition":"nbg-w8101","topic":"nbg-w8101-machine"}
{"level":"info","time":"2020-03-20T10:00:08.110Z","caller":"metal-api/main.go:372","message":"ipam initialized"}
{"level":"info","time":"2020-03-20T10:00:08.110Z","caller":"service/machine-service.go:1794","message":"machine resurrection was requested"}
{"level":"info","time":"2020-03-20T10:00:08.210Z","caller":"service/machine-service.go:1825","message":"resurrecting dead machine","machineID":"a7cac400-681b-11e9-8000-efbeaddeefbe","liveliness":"Dead","since":"93h0m55.432789622s"}
{"level":"error","time":"2020-03-20T10:00:08.210Z","caller":"service/machine-service.go:1828","message":"error during machine resurrection","machineID":"a7cac400-681b-11e9-8000-efbeaddeefbe","error":"machine is locked"}
```

