### PR TITLE
Changing firewall find HTTP method to POST.

### DIFF
--- a/cmd/metal-api/internal/service/firewall-service.go
+++ b/cmd/metal-api/internal/service/firewall-service.go
@@ -2,8 +2,9 @@ package service
 
 import (
 	"fmt"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/grpc"
 	"net/http"
+
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/grpc"
 
 	"github.com/metal-stack/metal-lib/httperrors"
 	"github.com/metal-stack/metal-lib/zapup"
@@ -76,7 +77,7 @@ func (r firewallResource) webService() *restful.WebService {
 		Returns(http.StatusOK, "OK", v1.FirewallResponse{}).
 		DefaultReturns("Error", httperrors.HTTPErrorResponse{}))
 
-	ws.Route(ws.GET("/find").
+	ws.Route(ws.POST("/find").
 		To(viewer(r.findFirewalls)).
 		Operation("findFirewalls").
 		Doc("find firewalls by multiple criteria").

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -3053,7 +3053,7 @@
       }
     },
     "/v1/firewall/find": {
-      "get": {
+      "post": {
         "consumes": [
           "application/json"
         ],


### PR DESCRIPTION
Prior definition was GET even though a search query payload needs to be transmitted in the request, which is invalid for certain HTTP clients.