### PR TITLE
first try

### DIFF
--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -36,8 +36,8 @@ type integerinfo struct {
 	IsInitialized bool   `rethinkdb:"isInitialized" json:"isInitialized"`
 }
 
-// GetInterPool returns a named integerpool if already created
-func (rs *RethinkStore) GetInterPool(name string) (*IntegerPool, error) {
+// GetIntegerPool returns a named integerpool if already created
+func (rs *RethinkStore) GetIntegerPool(name string) (*IntegerPool, error) {
 	ip, ok := rs.IntegerPools[name]
 	if !ok {
 		return nil, fmt.Errorf("no integerpool for %s created", name)

--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -106,10 +106,7 @@ func (rs *RethinkStore) NewIntegerPool(name string, min, max uint32) (*IntegerPo
 
 // AcquireRandomUniqueInteger returns a random unique integer from the pool.
 func (ip *IntegerPool) AcquireRandomUniqueInteger() (uint32, error) {
-	i := integer{
-		Name: ip.name,
-	}
-	t := ip.rs.integerTable().Get(i).Limit(1)
+	t := ip.rs.integerTable().Get(map[string]interface{}{"name": ip.name}).Limit(1)
 	return ip.genericAcquire(&t)
 }
 

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -117,8 +117,8 @@ func TestRethinkStore_AcquireRandomUniqueInteger(t *testing.T) {
 	ip := IntegerPool{rs: rs, name: "vrf", min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
 	rs.IntegerPools["vrf"] = &ip
 
-	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(IntegerPoolRangeMin)}}}
-	mock.On(r.DB("mockdb").Table("integerpool").Limit(1).Delete(r.
+	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"name": "vrf", "id": float64(IntegerPoolRangeMin)}}}
+	mock.On(r.DB("mockdb").Table("integerpool").Get(map[string]interface{}{"name": "vrf", "id": float64(IntegerPoolRangeMin)}).Limit(1).Delete(r.
 		DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes}, nil)
 
 	got, err := ip.AcquireRandomUniqueInteger()

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -118,7 +118,7 @@ func TestRethinkStore_AcquireRandomUniqueInteger(t *testing.T) {
 	rs.IntegerPools["vrf"] = &ip
 
 	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"name": "vrf", "id": float64(IntegerPoolRangeMin)}}}
-	mock.On(r.DB("mockdb").Table("integerpool").Get(map[string]interface{}{"name": "vrf", "id": float64(IntegerPoolRangeMin)}).Limit(1).Delete(r.
+	mock.On(r.DB("mockdb").Table("integerpool").Get(map[string]interface{}{"name": "vrf"}).Limit(1).Delete(r.
 		DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes}, nil)
 
 	got, err := ip.AcquireRandomUniqueInteger()
@@ -158,7 +158,7 @@ func TestRethinkStore_AcquireUniqueInteger(t *testing.T) {
 			if tt.requiresMock {
 				changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"name": "vrf", "id": float64(
 					tt.value)}}}
-				mock.On(r.DB("mockdb").Table("integerpool").Get(map[string]interface{}{"name": "vrf", "id": tt.value}).Delete(r.
+				mock.On(r.DB("mockdb").Table("integerpool").Get(map[string]interface{}{"id": tt.value, "name": "vrf"}).Delete(r.
 					DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes}, tt.err)
 			}
 

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -84,9 +84,7 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-
-			ip := IntegerPool{rs: rs, name: "vrf", min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
-			rs.IntegerPools["vrf"] = &ip
+			ip := rs.IntegerPools["vrf"]
 
 			if tt.requiresMock {
 				if tt.err != nil {
@@ -114,8 +112,7 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 
 func TestRethinkStore_AcquireRandomUniqueInteger(t *testing.T) {
 	rs, mock := InitMockDB()
-	ip := IntegerPool{rs: rs, name: "vrf", min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
-	rs.IntegerPools["vrf"] = &ip
+	ip := rs.IntegerPools["vrf"]
 
 	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"name": "vrf", "id": float64(IntegerPoolRangeMin)}}}
 	mock.On(r.DB("mockdb").Table("integerpool").Get(map[string]interface{}{"name": "vrf"}).Limit(1).Delete(r.
@@ -152,8 +149,7 @@ func TestRethinkStore_AcquireUniqueInteger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip := IntegerPool{rs: rs, name: "vrf", min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
-			rs.IntegerPools["vrf"] = &ip
+			ip := rs.IntegerPools["vrf"]
 
 			if tt.requiresMock {
 				changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"name": "vrf", "id": float64(
@@ -219,8 +215,7 @@ func TestRethinkStore_genericAcquire(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip := IntegerPool{rs: rs, name: "vrf", min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
-			rs.IntegerPools["vrf"] = &ip
+			ip := rs.IntegerPools["vrf"]
 
 			term := rs.integerTable().Get(tt.value)
 			if tt.requiresMock {

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -12,9 +12,17 @@ import (
 	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
 )
 
+const (
+	// VRFIntegerPoolName defines the name of the integerpool for VRFs
+	VRFIntegerPoolName = "vrf"
+	// ASNIntegerPoolName defines the name of the integerpool for ASNs
+	ASNIntegerPoolName = "asn"
+)
+
 var (
 	tables = []string{"image", "size", "partition", "machine", "switch", "wait", "event", "network", "ip",
 		"integerpool", "integerpoolinfo"}
+	integerPools = []string{VRFIntegerPoolName, ASNIntegerPoolName}
 )
 
 // A RethinkStore is the database access layer for rethinkdb.
@@ -24,10 +32,11 @@ type RethinkStore struct {
 	dbsession *r.Session
 	database  *r.Term
 
-	dbname string
-	dbuser string
-	dbpass string
-	dbhost string
+	dbname       string
+	dbuser       string
+	dbpass       string
+	dbhost       string
+	IntegerPools map[string]*IntegerPool
 }
 
 // New creates a new rethink store.
@@ -38,6 +47,7 @@ func New(log *zap.Logger, dbhost string, dbname string, dbuser string, dbpass st
 		dbname:        dbname,
 		dbuser:        dbuser,
 		dbpass:        dbpass,
+		IntegerPools:  make(map[string]*IntegerPool),
 	}
 }
 
@@ -81,9 +91,12 @@ func (rs *RethinkStore) initializeTables(opts r.TableCreateOpts) error {
 		return err
 	}
 
-	err = rs.initIntegerPool()
-	if err != nil {
-		return err
+	for _, pool := range integerPools {
+		ip, err := rs.NewIntegerPool(pool, IntegerPoolRangeMin, IntegerPoolRangeMax)
+		if err != nil {
+			return err
+		}
+		rs.IntegerPools[pool] = ip
 	}
 
 	return nil

--- a/cmd/metal-api/internal/datastore/testing.go
+++ b/cmd/metal-api/internal/datastore/testing.go
@@ -34,6 +34,10 @@ func InitMockDB() (*RethinkStore, *r.Mock) {
 		"db-password",
 	)
 	mock := rs.Mock()
+	vrfPool := IntegerPool{rs: rs, name: "vrf", min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
+	asnPool := IntegerPool{rs: rs, name: "asn", min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
+	rs.IntegerPools["vrf"] = &vrfPool
+	rs.IntegerPools["asn"] = &asnPool
 	return rs, mock
 }
 

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -336,7 +336,7 @@ func (r networkResource) createNetwork(request *restful.Request, response *restf
 	}
 
 	if vrf != 0 {
-		vrfPool, err := r.ds.GetInterPool(datastore.VRFIntegerPoolName)
+		vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPoolName)
 		if err != nil {
 			if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("could not acquire vrf: %v", err)) {
 				return
@@ -469,7 +469,7 @@ func (r networkResource) allocateNetwork(request *restful.Request, response *res
 }
 
 func createChildNetwork(ds *datastore.RethinkStore, ipamer ipam.IPAMer, nwSpec *metal.Network, parent *metal.Network, childLength int) (*metal.Network, error) {
-	vrfPool, err := ds.GetInterPool(datastore.VRFIntegerPoolName)
+	vrfPool, err := ds.GetIntegerPool(datastore.VRFIntegerPoolName)
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +539,7 @@ func (r networkResource) freeNetwork(request *restful.Request, response *restful
 		}
 	}
 
-	vrfPool, err := r.ds.GetInterPool(datastore.VRFIntegerPoolName)
+	vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPoolName)
 	if err != nil {
 		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("could not release vrf: %v", err)) {
 			return
@@ -688,7 +688,7 @@ func (r networkResource) deleteNetwork(request *restful.Request, response *restf
 		}
 	}
 
-	vrfPool, err := r.ds.GetInterPool(datastore.VRFIntegerPoolName)
+	vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPoolName)
 	if err != nil {
 		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("could not release vrf: %v", err)) {
 			return


### PR DESCRIPTION
Make the Integerpool configurable for different consumers. This is done by adding a name field to every ID in both tables integer and integerinfo.

This PR still lacks migration of existing data, unit tests failing, etc. 