### PR TITLE
Seperate integer pool

### DIFF
--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -34,7 +34,7 @@ type integerinfo struct {
 
 // GetIntegerPool returns a named integerpool if already created
 func (rs *RethinkStore) GetIntegerPool(name string) (*IntegerPool, error) {
-	ip, ok := rs.IntegerPools[name]
+	ip, ok := rs.integerPools[name]
 	if !ok {
 		return nil, fmt.Errorf("no integerpool for %s created", name)
 	}

--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -15,16 +15,33 @@ var (
 	IntegerPoolRangeMax = uint(131072)
 )
 
+// IntegerPool manages unique integers
+type IntegerPool struct {
+	tablename string
+	min       uint
+	max       uint
+	rs        *RethinkStore
+}
+
 type integer struct {
 	ID uint `rethinkdb:"id" json:"id"`
 }
 
-// Integerinfo contains information on the integer pool.
-type Integerinfo struct {
+// integerinfo contains information on the integer pool.
+type integerinfo struct {
 	IsInitialized bool `rethinkdb:"isInitialized" json:"isInitialized"`
 }
 
-// initIntegerPool initializes a pool to acquire unique integers from.
+// GetIntegerPool returns a named integerpool if already created
+func (rs *RethinkStore) GetIntegerPool(name string) (*IntegerPool, error) {
+	ip, ok := rs.IntegerPools[name]
+	if !ok {
+		return nil, fmt.Errorf("no integerpool for %s created", name)
+	}
+	return ip, nil
+}
+
+// NewIntegerPool initializes a pool to acquire unique integers from.
 // the acquired integers are used from the network service for defining the:
 // - vrf name
 // - vni
@@ -51,49 +68,54 @@ type Integerinfo struct {
 // - releasing the integer is fast
 // - you do not have gaps (because you can give the integers back to the pool)
 // - everything can be done atomically, so there are no race conditions
-func (rs *RethinkStore) initIntegerPool() error {
-
-	var result Integerinfo
-	err := rs.findEntityByID(rs.integerInfoTable(), &result, "integerpool")
+func (rs *RethinkStore) NewIntegerPool(tablename string, min, max uint) (*IntegerPool, error) {
+	var result integerinfo
+	err := rs.findEntityByID(rs.integerInfoTable(tablename), &result, tablename)
 	if err != nil {
 		if !metal.IsNotFound(err) {
-			return err
+			return nil, err
 		}
 	}
 
+	ip := &IntegerPool{
+		tablename: tablename,
+		min:       min,
+		max:       max,
+		rs:        rs,
+	}
 	if result.IsInitialized {
-		return nil
+		return ip, nil
 	}
 
-	rs.SugaredLogger.Infow("Initializing integer pool", "RangeMin", IntegerPoolRangeMin, "RangeMax", IntegerPoolRangeMax)
-	intRange := makeRange(IntegerPoolRangeMin, IntegerPoolRangeMax)
-	_, err = rs.integerTable().Insert(intRange).RunWrite(rs.session, r.RunOpts{ArrayLimit: IntegerPoolRangeMax})
+	rs.SugaredLogger.Infow("Initializing integer pool", "for", tablename, "RangeMin", min, "RangeMax", max)
+	intRange := makeRange(min, max)
+	_, err = rs.integerTable(tablename).Insert(intRange).RunWrite(rs.session, r.RunOpts{ArrayLimit: max})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rs.integerInfoTable().Insert(map[string]interface{}{"id": "integerpool", "IsInitialized": true}).RunWrite(rs.session)
-	return err
+	_, err = rs.integerInfoTable(tablename).Insert(map[string]interface{}{"IsInitialized": true}).RunWrite(rs.session)
+	return ip, err
 }
 
 // AcquireRandomUniqueInteger returns a random unique integer from the pool.
-func (rs *RethinkStore) AcquireRandomUniqueInteger() (uint, error) {
-	t := rs.integerTable().Limit(1)
-	return rs.genericAcquire(&t)
+func (ip *IntegerPool) AcquireRandomUniqueInteger() (uint, error) {
+	t := ip.rs.integerTable(ip.tablename).Limit(1)
+	return ip.genericAcquire(&t)
 }
 
 // AcquireUniqueInteger returns a unique integer from the pool.
-func (rs *RethinkStore) AcquireUniqueInteger(value uint) (uint, error) {
-	err := verifyRange(value)
+func (ip *IntegerPool) AcquireUniqueInteger(value uint) (uint, error) {
+	err := ip.verifyRange(value)
 	if err != nil {
 		return 0, err
 	}
-	t := rs.integerTable().Get(value)
-	return rs.genericAcquire(&t)
+	t := ip.rs.integerTable(ip.tablename).Get(value)
+	return ip.genericAcquire(&t)
 }
 
 // ReleaseUniqueInteger returns a unique integer to the pool.
-func (rs *RethinkStore) ReleaseUniqueInteger(id uint) error {
-	err := verifyRange(id)
+func (ip *IntegerPool) ReleaseUniqueInteger(id uint) error {
+	err := ip.verifyRange(id)
 	if err != nil {
 		return err
 	}
@@ -101,7 +123,7 @@ func (rs *RethinkStore) ReleaseUniqueInteger(id uint) error {
 	i := integer{
 		ID: id,
 	}
-	_, err = rs.integerTable().Insert(i, r.InsertOpts{Conflict: "replace"}).RunWrite(rs.session)
+	_, err = ip.rs.integerTable(ip.tablename).Insert(i, r.InsertOpts{Conflict: "replace"}).RunWrite(ip.rs.session)
 	if err != nil {
 		return err
 	}
@@ -109,14 +131,14 @@ func (rs *RethinkStore) ReleaseUniqueInteger(id uint) error {
 	return nil
 }
 
-func (rs *RethinkStore) genericAcquire(term *r.Term) (uint, error) {
-	res, err := term.Delete(r.DeleteOpts{ReturnChanges: true}).RunWrite(rs.session)
+func (ip *IntegerPool) genericAcquire(term *r.Term) (uint, error) {
+	res, err := term.Delete(r.DeleteOpts{ReturnChanges: true}).RunWrite(ip.rs.session)
 	if err != nil {
 		return 0, err
 	}
 
 	if len(res.Changes) == 0 {
-		res, err := rs.integerTable().Count().Run(rs.session)
+		res, err := ip.rs.integerTable(ip.tablename).Count().Run(ip.rs.session)
 		if err != nil {
 			return 0, err
 		}
@@ -128,9 +150,8 @@ func (rs *RethinkStore) genericAcquire(term *r.Term) (uint, error) {
 
 		if count <= 0 {
 			return 0, metal.Internal(fmt.Errorf("acquisition of a value failed for exhausted pool"), "")
-		} else {
-			return 0, metal.Conflict("integer is already acquired by another")
 		}
+		return 0, metal.Conflict("integer is already acquired by another")
 	}
 
 	result := uint(res.Changes[0].OldValue.(map[string]interface{})["id"].(float64))
@@ -147,9 +168,9 @@ func makeRange(min, max uint) []integer {
 	return a
 }
 
-func verifyRange(value uint) error {
-	if value < IntegerPoolRangeMin || value > IntegerPoolRangeMax {
-		return fmt.Errorf("value '%d' is outside of the allowed range '%d - %d'", value, IntegerPoolRangeMin, IntegerPoolRangeMax)
+func (ip *IntegerPool) verifyRange(value uint) error {
+	if value < ip.min || value > ip.max {
+		return fmt.Errorf("value '%d' is outside of the allowed range '%d - %d'", value, ip.min, ip.max)
 	}
 	return nil
 }

--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -9,10 +9,14 @@ import (
 )
 
 var (
-	// IntegerPoolRangeMin the minimum integer to get from the pool
-	IntegerPoolRangeMin = uint(1)
-	// IntegerPoolRangeMax the maximum integer to get from the pool
-	IntegerPoolRangeMax = uint(131072)
+	// VRFPoolRangeMin the minimum integer to get from the vrf pool
+	VRFPoolRangeMin = uint(1)
+	// VRFPoolRangeMax the maximum integer to get from the vrf pool
+	VRFPoolRangeMax = uint(131072)
+	// ASNPoolRangeMin the minimum integer to get from the asn pool
+	ASNPoolRangeMin = uint(1)
+	// ASNPoolRangeMax the maximum integer to get from the asn pool
+	ASNPoolRangeMax = uint(131072)
 )
 
 // IntegerPool manages unique integers

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -76,7 +76,7 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 		{
 			name:         "verify validation of input fails",
 			value:        524288,
-			err:          fmt.Errorf("value '524288' is outside of the allowed range '%d - %d'", IntegerPoolRangeMin, IntegerPoolRangeMax),
+			err:          fmt.Errorf("value '524288' is outside of the allowed range '%d - %d'", VRFPoolRangeMin, VRFPoolRangeMax),
 			requiresMock: false,
 		},
 	}
@@ -114,13 +114,13 @@ func TestRethinkStore_AcquireRandomUniqueInteger(t *testing.T) {
 	rs, mock := InitMockDB()
 	ip, err := rs.GetIntegerPool(VRFIntegerPoolName)
 	assert.NoError(t, err)
-	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(IntegerPoolRangeMin)}}}
+	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(VRFPoolRangeMin)}}}
 	mock.On(r.DB("mockdb").Table(ip.tablename).Limit(1).Delete(r.
 		DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes}, nil)
 
 	got, err := ip.AcquireRandomUniqueInteger()
 	assert.NoError(t, err)
-	assert.EqualValues(t, IntegerPoolRangeMin, got)
+	assert.EqualValues(t, VRFPoolRangeMin, got)
 
 	mock.AssertExpectations(t)
 }
@@ -141,7 +141,7 @@ func TestRethinkStore_AcquireUniqueInteger(t *testing.T) {
 		{
 			name:         "verify validation of input fails",
 			value:        524288,
-			err:          fmt.Errorf("value '524288' is outside of the allowed range '%d - %d'", IntegerPoolRangeMin, IntegerPoolRangeMax),
+			err:          fmt.Errorf("value '524288' is outside of the allowed range '%d - %d'", VRFPoolRangeMin, VRFPoolRangeMax),
 			requiresMock: false,
 		},
 	}

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -84,7 +84,7 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip, err := rs.GetIntegerPool(VRFIntegerPoolName)
+			ip, err := rs.GetIntegerPool(VRFIntegerPool)
 			assert.NoError(t, err)
 			if tt.requiresMock {
 				if tt.err != nil {
@@ -112,7 +112,7 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 
 func TestRethinkStore_AcquireRandomUniqueInteger(t *testing.T) {
 	rs, mock := InitMockDB()
-	ip, err := rs.GetIntegerPool(VRFIntegerPoolName)
+	ip, err := rs.GetIntegerPool(VRFIntegerPool)
 	assert.NoError(t, err)
 	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(VRFPoolRangeMin)}}}
 	mock.On(r.DB("mockdb").Table(ip.tablename).Limit(1).Delete(r.
@@ -149,7 +149,7 @@ func TestRethinkStore_AcquireUniqueInteger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip, err := rs.GetIntegerPool(VRFIntegerPoolName)
+			ip, err := rs.GetIntegerPool(VRFIntegerPool)
 			assert.NoError(t, err)
 
 			if tt.requiresMock {
@@ -216,7 +216,7 @@ func TestRethinkStore_genericAcquire(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip, err := rs.GetIntegerPool(VRFIntegerPoolName)
+			ip, err := rs.GetIntegerPool(VRFIntegerPool)
 			assert.NoError(t, err)
 
 			term := rs.integerTable(ip.tablename).Get(tt.value)

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -20,6 +20,7 @@ const (
 )
 
 var (
+	// FIXME move old integerpool/integerpoolinfo to vrfpool
 	tables = []string{"image", "size", "partition", "machine", "switch", "wait", "event", "network", "ip",
 		VRFIntegerPoolName, VRFIntegerPoolName + "info",
 		ASNIntegerPoolName, ASNIntegerPoolName + "info"}

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -12,18 +12,10 @@ import (
 	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
 )
 
-const (
-	// VRFIntegerPoolName defines the name of the pool for VRFs
-	// FIXME, must be renamed to vrfpool later
-	VRFIntegerPoolName = "integerpool"
-	// ASNIntegerPoolName defines the name of the pool for ASNs
-	ASNIntegerPoolName = "asnpool"
-)
-
 var (
 	tables = []string{"image", "size", "partition", "machine", "switch", "wait", "event", "network", "ip",
-		VRFIntegerPoolName, VRFIntegerPoolName + "info",
-		ASNIntegerPoolName, ASNIntegerPoolName + "info"}
+		VRFIntegerPool.String(), VRFIntegerPool.String() + "info",
+		ASNIntegerPool.String(), ASNIntegerPool.String() + "info"}
 )
 
 // A RethinkStore is the database access layer for rethinkdb.
@@ -37,7 +29,7 @@ type RethinkStore struct {
 	dbuser       string
 	dbpass       string
 	dbhost       string
-	integerPools map[string]*IntegerPool
+	integerPools map[IntegerPoolType]*IntegerPool
 }
 
 // New creates a new rethink store.
@@ -48,7 +40,7 @@ func New(log *zap.Logger, dbhost string, dbname string, dbuser string, dbpass st
 		dbname:        dbname,
 		dbuser:        dbuser,
 		dbpass:        dbpass,
-		integerPools:  make(map[string]*IntegerPool),
+		integerPools:  make(map[IntegerPoolType]*IntegerPool),
 	}
 }
 
@@ -100,17 +92,17 @@ func (rs *RethinkStore) initializeTables(opts r.TableCreateOpts) error {
 		return err
 	}
 
-	vrfPool, err := rs.initIntegerPool(VRFIntegerPoolName, VRFPoolRangeMin, VRFPoolRangeMax)
+	vrfPool, err := rs.initIntegerPool(VRFIntegerPool, VRFPoolRangeMin, VRFPoolRangeMax)
 	if err != nil {
 		return err
 	}
-	rs.integerPools[VRFIntegerPoolName] = vrfPool
+	rs.integerPools[VRFIntegerPool] = vrfPool
 
-	asnPool, err := rs.initIntegerPool(ASNIntegerPoolName, ASNPoolRangeMin, ASNPoolRangeMax)
+	asnPool, err := rs.initIntegerPool(ASNIntegerPool, ASNPoolRangeMin, ASNPoolRangeMax)
 	if err != nil {
 		return err
 	}
-	rs.integerPools[ASNIntegerPoolName] = asnPool
+	rs.integerPools[ASNIntegerPool] = asnPool
 
 	return nil
 }

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -14,7 +14,8 @@ import (
 
 const (
 	// VRFIntegerPoolName defines the name of the pool for VRFs
-	VRFIntegerPoolName = "vrfpool"
+	// FIXME, must be renamed to vrfpool later
+	VRFIntegerPoolName = "integerpool"
 	// ASNIntegerPoolName defines the name of the pool for ASNs
 	ASNIntegerPoolName = "asnpool"
 )
@@ -80,13 +81,13 @@ func (rs *RethinkStore) initializeTables(opts r.TableCreateOpts) error {
 
 	err := multi(rs.session,
 		// rename old integerpool to vrfpool
-		// FIXME can be removed once migrated
-		db.TableList().Contains("integerpool").Do(func(r r.Term) r.Term {
-			return db.Table("integerpool").Config().Update(map[string]interface{}{"name": VRFIntegerPoolName})
-		}),
-		db.TableList().Contains("integerpoolinfo").Do(func(r r.Term) r.Term {
-			return db.Table("integerpoolinfo").Config().Update(map[string]interface{}{"name": VRFIntegerPoolName + "info"})
-		}),
+		// FIXME enable and remove once migrated
+		// db.TableList().Contains("integerpool").Do(func(r r.Term) r.Term {
+		// 	return db.Table("integerpool").Config().Update(map[string]interface{}{"name": VRFIntegerPoolName})
+		// }),
+		// db.TableList().Contains("integerpoolinfo").Do(func(r r.Term) r.Term {
+		// 	return db.Table("integerpoolinfo").Config().Update(map[string]interface{}{"name": VRFIntegerPoolName + "info"})
+		// }),
 		// create our tables
 		r.Expr(tables).Difference(db.TableList()).ForEach(func(r r.Term) r.Term {
 			return db.TableCreate(r, opts)
@@ -101,7 +102,7 @@ func (rs *RethinkStore) initializeTables(opts r.TableCreateOpts) error {
 	}
 
 	for _, pool := range integerPools {
-		ip, err := rs.NewIntegerPool(pool, IntegerPoolRangeMin, IntegerPoolRangeMax)
+		ip, err := rs.initIntegerPool(pool, IntegerPoolRangeMin, IntegerPoolRangeMax)
 		if err != nil {
 			return err
 		}

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -38,7 +38,7 @@ type RethinkStore struct {
 	dbuser       string
 	dbpass       string
 	dbhost       string
-	IntegerPools map[string]*IntegerPool
+	integerPools map[string]*IntegerPool
 }
 
 // New creates a new rethink store.
@@ -49,7 +49,7 @@ func New(log *zap.Logger, dbhost string, dbname string, dbuser string, dbpass st
 		dbname:        dbname,
 		dbuser:        dbuser,
 		dbpass:        dbpass,
-		IntegerPools:  make(map[string]*IntegerPool),
+		integerPools:  make(map[string]*IntegerPool),
 	}
 }
 
@@ -98,7 +98,7 @@ func (rs *RethinkStore) initializeTables(opts r.TableCreateOpts) error {
 		if err != nil {
 			return err
 		}
-		rs.IntegerPools[pool] = ip
+		rs.integerPools[pool] = ip
 	}
 	return nil
 }

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -24,7 +24,6 @@ var (
 	tables = []string{"image", "size", "partition", "machine", "switch", "wait", "event", "network", "ip",
 		VRFIntegerPoolName, VRFIntegerPoolName + "info",
 		ASNIntegerPoolName, ASNIntegerPoolName + "info"}
-	integerPools = []string{VRFIntegerPoolName, ASNIntegerPoolName}
 )
 
 // A RethinkStore is the database access layer for rethinkdb.
@@ -101,13 +100,18 @@ func (rs *RethinkStore) initializeTables(opts r.TableCreateOpts) error {
 		return err
 	}
 
-	for _, pool := range integerPools {
-		ip, err := rs.initIntegerPool(pool, IntegerPoolRangeMin, IntegerPoolRangeMax)
-		if err != nil {
-			return err
-		}
-		rs.integerPools[pool] = ip
+	vrfPool, err := rs.initIntegerPool(VRFIntegerPoolName, VRFPoolRangeMin, VRFPoolRangeMax)
+	if err != nil {
+		return err
 	}
+	rs.integerPools[VRFIntegerPoolName] = vrfPool
+
+	asnPool, err := rs.initIntegerPool(ASNIntegerPoolName, ASNPoolRangeMin, ASNPoolRangeMax)
+	if err != nil {
+		return err
+	}
+	rs.integerPools[ASNIntegerPoolName] = asnPool
+
 	return nil
 }
 

--- a/cmd/metal-api/internal/datastore/rethinkdb_test.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb_test.go
@@ -17,7 +17,7 @@ var (
 		dbname:        "dbname",
 		dbuser:        "dbuser",
 		dbpass:        "password",
-		IntegerPools:  make(map[string]*IntegerPool),
+		integerPools:  make(map[string]*IntegerPool),
 	}
 )
 

--- a/cmd/metal-api/internal/datastore/rethinkdb_test.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb_test.go
@@ -17,6 +17,7 @@ var (
 		dbname:        "dbname",
 		dbuser:        "dbuser",
 		dbpass:        "password",
+		IntegerPools:  make(map[string]*IntegerPool),
 	}
 )
 

--- a/cmd/metal-api/internal/datastore/rethinkdb_test.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb_test.go
@@ -17,7 +17,7 @@ var (
 		dbname:        "dbname",
 		dbuser:        "dbuser",
 		dbpass:        "password",
-		integerPools:  make(map[string]*IntegerPool),
+		integerPools:  make(map[IntegerPoolType]*IntegerPool),
 	}
 )
 

--- a/cmd/metal-api/internal/datastore/testing.go
+++ b/cmd/metal-api/internal/datastore/testing.go
@@ -36,8 +36,8 @@ func InitMockDB() (*RethinkStore, *r.Mock) {
 	mock := rs.Mock()
 	vrfPool := IntegerPool{tablename: VRFIntegerPoolName, rs: rs, min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
 	asnPool := IntegerPool{tablename: ASNIntegerPoolName, rs: rs, min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
-	rs.IntegerPools[vrfPool.tablename] = &vrfPool
-	rs.IntegerPools[asnPool.tablename] = &asnPool
+	rs.integerPools[vrfPool.tablename] = &vrfPool
+	rs.integerPools[asnPool.tablename] = &asnPool
 	return rs, mock
 }
 

--- a/cmd/metal-api/internal/datastore/testing.go
+++ b/cmd/metal-api/internal/datastore/testing.go
@@ -34,8 +34,8 @@ func InitMockDB() (*RethinkStore, *r.Mock) {
 		"db-password",
 	)
 	mock := rs.Mock()
-	vrfPool := IntegerPool{tablename: VRFIntegerPoolName, rs: rs, min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
-	asnPool := IntegerPool{tablename: ASNIntegerPoolName, rs: rs, min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
+	vrfPool := IntegerPool{tablename: VRFIntegerPoolName, rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
+	asnPool := IntegerPool{tablename: ASNIntegerPoolName, rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
 	rs.integerPools[vrfPool.tablename] = &vrfPool
 	rs.integerPools[asnPool.tablename] = &asnPool
 	return rs, mock
@@ -65,8 +65,8 @@ func InitTestDB(t *testing.T) (*RethinkStore, testcontainers.Container, context.
 		dbuser:        "",
 		dbpass:        "",
 	}
-	IntegerPoolRangeMin = 10000
-	IntegerPoolRangeMax = 10010
+	VRFPoolRangeMin = 10000
+	VRFPoolRangeMax = 10010
 	err = rs.Connect()
 	assert.NoError(t, err)
 	return rs, c, ctx

--- a/cmd/metal-api/internal/datastore/testing.go
+++ b/cmd/metal-api/internal/datastore/testing.go
@@ -34,6 +34,10 @@ func InitMockDB() (*RethinkStore, *r.Mock) {
 		"db-password",
 	)
 	mock := rs.Mock()
+	vrfPool := IntegerPool{tablename: VRFIntegerPoolName, rs: rs, min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
+	asnPool := IntegerPool{tablename: ASNIntegerPoolName, rs: rs, min: IntegerPoolRangeMin, max: IntegerPoolRangeMax}
+	rs.IntegerPools[vrfPool.tablename] = &vrfPool
+	rs.IntegerPools[asnPool.tablename] = &asnPool
 	return rs, mock
 }
 

--- a/cmd/metal-api/internal/datastore/testing.go
+++ b/cmd/metal-api/internal/datastore/testing.go
@@ -34,8 +34,10 @@ func InitMockDB() (*RethinkStore, *r.Mock) {
 		"db-password",
 	)
 	mock := rs.Mock()
-	vrfPool := IntegerPool{tablename: VRFIntegerPool.String(), rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
-	asnPool := IntegerPool{tablename: ASNIntegerPool.String(), rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
+	vrfterm := rs.integerTable(VRFIntegerPool.String())
+	asnterm := rs.integerTable(VRFIntegerPool.String())
+	vrfPool := IntegerPool{tablename: VRFIntegerPool.String(), min: VRFPoolRangeMin, max: VRFPoolRangeMax, term: vrfterm, session: rs.session}
+	asnPool := IntegerPool{tablename: ASNIntegerPool.String(), min: ASNPoolRangeMin, max: ASNPoolRangeMax, term: asnterm, session: rs.session}
 	rs.integerPools[VRFIntegerPool] = &vrfPool
 	rs.integerPools[ASNIntegerPool] = &asnPool
 	return rs, mock

--- a/cmd/metal-api/internal/datastore/testing.go
+++ b/cmd/metal-api/internal/datastore/testing.go
@@ -34,10 +34,10 @@ func InitMockDB() (*RethinkStore, *r.Mock) {
 		"db-password",
 	)
 	mock := rs.Mock()
-	vrfPool := IntegerPool{tablename: VRFIntegerPoolName, rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
-	asnPool := IntegerPool{tablename: ASNIntegerPoolName, rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
-	rs.integerPools[vrfPool.tablename] = &vrfPool
-	rs.integerPools[asnPool.tablename] = &asnPool
+	vrfPool := IntegerPool{tablename: VRFIntegerPool.String(), rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
+	asnPool := IntegerPool{tablename: ASNIntegerPool.String(), rs: rs, min: VRFPoolRangeMin, max: VRFPoolRangeMax}
+	rs.integerPools[VRFIntegerPool] = &vrfPool
+	rs.integerPools[ASNIntegerPool] = &asnPool
 	return rs, mock
 }
 

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -336,7 +336,7 @@ func (r networkResource) createNetwork(request *restful.Request, response *restf
 	}
 
 	if vrf != 0 {
-		vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPoolName)
+		vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPool)
 		if err != nil {
 			if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("could not acquire vrf: %v", err)) {
 				return
@@ -469,7 +469,7 @@ func (r networkResource) allocateNetwork(request *restful.Request, response *res
 }
 
 func createChildNetwork(ds *datastore.RethinkStore, ipamer ipam.IPAMer, nwSpec *metal.Network, parent *metal.Network, childLength int) (*metal.Network, error) {
-	vrfPool, err := ds.GetIntegerPool(datastore.VRFIntegerPoolName)
+	vrfPool, err := ds.GetIntegerPool(datastore.VRFIntegerPool)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +540,7 @@ func (r networkResource) freeNetwork(request *restful.Request, response *restful
 	}
 
 	if nw.Vrf != 0 {
-		vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPoolName)
+		vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPool)
 		if err != nil {
 			if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("could not release vrf: %v", err)) {
 				return
@@ -689,7 +689,7 @@ func (r networkResource) deleteNetwork(request *restful.Request, response *restf
 	}
 
 	if nw.Vrf != 0 {
-		vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPoolName)
+		vrfPool, err := r.ds.GetIntegerPool(datastore.VRFIntegerPool)
 		if err != nil {
 			if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("could not release vrf: %v", err)) {
 				return

--- a/cmd/metal-api/internal/testdata/testdata.go
+++ b/cmd/metal-api/internal/testdata/testdata.go
@@ -790,7 +790,7 @@ func InitMockDBData(mock *r.Mock) {
 	mock.On(r.DB("mockdb").Table("wait").Get("3").Changes()).Return([]interface{}{
 		map[string]interface{}{"new_val": M3},
 	}, nil)
-	mock.On(r.DB("mockdb").Table("vrfpool").Get(r.MockAnything()).Delete(r.DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: []r.ChangeResponse{r.ChangeResponse{OldValue: map[string]interface{}{"id": float64(12345)}}}}, nil)
+	mock.On(r.DB("mockdb").Table("integerpool").Get(r.MockAnything()).Delete(r.DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: []r.ChangeResponse{r.ChangeResponse{OldValue: map[string]interface{}{"id": float64(12345)}}}}, nil)
 
 	// Default: Return Empty result
 	mock.On(r.DB("mockdb").Table("size").Get(r.MockAnything())).Return(EmptyResult, nil)

--- a/cmd/metal-api/internal/testdata/testdata.go
+++ b/cmd/metal-api/internal/testdata/testdata.go
@@ -790,7 +790,7 @@ func InitMockDBData(mock *r.Mock) {
 	mock.On(r.DB("mockdb").Table("wait").Get("3").Changes()).Return([]interface{}{
 		map[string]interface{}{"new_val": M3},
 	}, nil)
-	mock.On(r.DB("mockdb").Table("integerpool").Get(r.MockAnything()).Delete(r.DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: []r.ChangeResponse{r.ChangeResponse{OldValue: map[string]interface{}{"id": float64(12345)}}}}, nil)
+	mock.On(r.DB("mockdb").Table("vrfpool").Get(r.MockAnything()).Delete(r.DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: []r.ChangeResponse{r.ChangeResponse{OldValue: map[string]interface{}{"id": float64(12345)}}}}, nil)
 
 	// Default: Return Empty result
 	mock.On(r.DB("mockdb").Table("size").Get(r.MockAnything())).Return(EmptyResult, nil)


### PR DESCRIPTION
Make integerpool configurable in two aspekts:

- create a named pool, one for each purpose (vrf and asn in this case)
- min and max are configurable per pool

this is a required modification to prevent pool exhaustion by asn allocation in #105.

Downside: pool initialization is now twice as long, which make mini-lab initialization  ~20 sec slower.