### PR TITLE
Do not send error string.

### DIFF
--- a/cmd/metal-api/internal/service/service.go
+++ b/cmd/metal-api/internal/service/service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -88,17 +87,8 @@ func sendError(log *zap.Logger, rsp *restful.Response, opname string, errRsp *ht
 
 func sendErrorImpl(log *zap.Logger, rsp *restful.Response, opname string, errRsp *httperrors.HTTPErrorResponse, stackup int) {
 	s := stack.Caller(stackup)
-	response, merr := json.Marshal(errRsp)
-	log.Error("service error", zap.String("operation", opname), zap.Int("status", errRsp.StatusCode), zap.String("error", errRsp.Message), zap.Stringer("service-caller", s), zap.String("resp", string(response)))
-	if merr != nil {
-		err := rsp.WriteError(http.StatusInternalServerError, fmt.Errorf("unable to format error string: %v", merr))
-		if err != nil {
-			log.Error("Failed to send response", zap.Error(err))
-			return
-		}
-		return
-	}
-	err := rsp.WriteErrorString(errRsp.StatusCode, string(response))
+	log.Error("service error", zap.String("operation", opname), zap.Int("status", errRsp.StatusCode), zap.String("error", errRsp.Message), zap.Stringer("service-caller", s), zap.String("resp", errRsp.Error()))
+	err := rsp.WriteHeaderAndEntity(errRsp.StatusCode, errRsp)
 	if err != nil {
 		log.Error("Failed to send response", zap.Error(err))
 		return


### PR DESCRIPTION
We always return plaintext error responses, which makes handling errors client-side very hard and confusing (round-tripper does JSON Unmarshaling and throws away original error type from swagger client).

This is how a response currently looks like:

``` 
HTTP/2.0 404 Not Found
Content-Length: 77
Content-Type: text/plain; charset=utf-8
Date: Mon, 05 Oct 2020 12:05:00 GMT
Server: nginx/1.17.8
Strict-Transport-Security: max-age=15724800; includeSubDomains

{"statuscode":404,"message":"no network with id \"test-01\" found: NotFound"}
```

With this pull request it will look like this:

```
HTTP/2.0 404 Not Found
Content-Length: 84
Content-Type: application/json
Date: Mon, 05 Oct 2020 12:36:28 GMT
Server: nginx/1.17.8
Strict-Transport-Security: max-age=15724800; includeSubDomains

{
 "statuscode": 404,
 "message": "no network with id \"test-02\" found: NotFound"
}
``` 

Then, we can start handle errors in clients properly like this (requires to remove the RoundTripper from metal-go though, because it destroys the original error type):

```go
resp, err := driver.NetworkGet(*nar.ID)
if err != nil {
	switch e := err.(type) {
	case *networkmodel.FindNetworkDefault:
                // this part in the code can now be reached, which is impossible with the current impl
		if e.Code() != http.StatusNotFound {
			return fmt.Errorf("network get error:%v", e.Error())
		}
	default:
		return fmt.Errorf("unexpected error on network get:%v", err)
	}
}
```

(should also remove confusing "TextUmarshaller missing" issues!)