### PR TITLE
Add switch VRF update to async machine release mechanism.

### DIFF
--- a/cmd/metal-api/internal/service/firewall-service.go
+++ b/cmd/metal-api/internal/service/firewall-service.go
@@ -35,6 +35,7 @@ type firewallResource struct {
 // NewFirewall returns a webservice for firewall specific endpoints.
 func NewFirewall(
 	ds *datastore.RethinkStore,
+	pub bus.Publisher,
 	ipamer ipam.IPAMer,
 	ep *bus.Endpoints,
 	mdc mdm.Client,
@@ -49,7 +50,7 @@ func NewFirewall(
 	}
 
 	var err error
-	r.actor, err = newAsyncActor(zapup.MustRootLogger(), ep, ds, ipamer)
+	r.actor, err = newAsyncActor(zapup.MustRootLogger(), ep, ds, ipamer, pub)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create async actor: %w", err)
 	}

--- a/cmd/metal-api/internal/service/integration_test.go
+++ b/cmd/metal-api/internal/service/integration_test.go
@@ -73,7 +73,7 @@ func createTestEnvironment(t *testing.T) testEnv {
 	sizeService := NewSize(ds)
 	networkService := NewNetwork(ds, ipamer, mdc)
 	partitionService := NewPartition(ds, nsq)
-	ipService, err := NewIP(ds, nsq.Endpoints, ipamer, mdc)
+	ipService, err := NewIP(ds, nsq.Publisher, nsq.Endpoints, ipamer, mdc)
 	require.NoError(err)
 
 	te := testEnv{

--- a/cmd/metal-api/internal/service/ip-service.go
+++ b/cmd/metal-api/internal/service/ip-service.go
@@ -34,7 +34,7 @@ type ipResource struct {
 }
 
 // NewIP returns a webservice for ip specific endpoints.
-func NewIP(ds *datastore.RethinkStore, ep *bus.Endpoints, ipamer ipam.IPAMer, mdc mdm.Client) (*restful.WebService, error) {
+func NewIP(ds *datastore.RethinkStore, pub bus.Publisher, ep *bus.Endpoints, ipamer ipam.IPAMer, mdc mdm.Client) (*restful.WebService, error) {
 	ir := ipResource{
 		webResource: webResource{
 			ds: ds,
@@ -43,7 +43,7 @@ func NewIP(ds *datastore.RethinkStore, ep *bus.Endpoints, ipamer ipam.IPAMer, md
 		mdc:    mdc,
 	}
 	var err error
-	ir.actor, err = newAsyncActor(zapup.MustRootLogger(), ep, ds, ipamer)
+	ir.actor, err = newAsyncActor(zapup.MustRootLogger(), ep, ds, ipamer, pub)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create async actor: %w", err)
 	}

--- a/cmd/metal-api/internal/service/ip-service_test.go
+++ b/cmd/metal-api/internal/service/ip-service_test.go
@@ -34,7 +34,7 @@ func TestGetIPs(t *testing.T) {
 	ds, mock := datastore.InitMockDB()
 	testdata.InitMockDBData(mock)
 
-	ipservice, err := NewIP(ds, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
+	ipservice, err := NewIP(ds, nil, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
 	require.NoError(t, err)
 
 	container := restful.NewContainer().Add(ipservice)
@@ -62,7 +62,7 @@ func TestGetIP(t *testing.T) {
 	ds, mock := datastore.InitMockDB()
 	testdata.InitMockDBData(mock)
 
-	ipservice, err := NewIP(ds, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
+	ipservice, err := NewIP(ds, nil, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
 	require.NoError(t, err)
 	container := restful.NewContainer().Add(ipservice)
 	req := httptest.NewRequest("GET", "/v1/ip/1.2.3.4", nil)
@@ -84,7 +84,7 @@ func TestGetIPNotFound(t *testing.T) {
 	ds, mock := datastore.InitMockDB()
 	testdata.InitMockDBData(mock)
 
-	ipservice, err := NewIP(ds, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
+	ipservice, err := NewIP(ds, nil, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
 	require.NoError(t, err)
 	container := restful.NewContainer().Add(ipservice)
 	req := httptest.NewRequest("GET", "/v1/ip/9.9.9.9", nil)
@@ -108,7 +108,7 @@ func TestDeleteIP(t *testing.T) {
 	require.Nil(t, err)
 	testdata.InitMockDBData(mock)
 
-	ipservice, err := NewIP(ds, bus.DirectEndpoints(), ipamer, nil)
+	ipservice, err := NewIP(ds, nil, bus.DirectEndpoints(), ipamer, nil)
 	require.NoError(t, err)
 	container := restful.NewContainer().Add(ipservice)
 
@@ -168,7 +168,7 @@ func TestAllocateIP(t *testing.T) {
 
 	mdc := mdm.NewMock(&psc, &tsc)
 
-	ipservice, err := NewIP(ds, bus.DirectEndpoints(), ipamer, mdc)
+	ipservice, err := NewIP(ds, nil, bus.DirectEndpoints(), ipamer, mdc)
 	require.NoError(t, err)
 	container := restful.NewContainer().Add(ipservice)
 
@@ -228,7 +228,7 @@ func TestUpdateIP(t *testing.T) {
 	ds, mock := datastore.InitMockDB()
 	testdata.InitMockDBData(mock)
 
-	ipservice, err := NewIP(ds, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
+	ipservice, err := NewIP(ds, nil, bus.DirectEndpoints(), ipam.New(goipam.New()), nil)
 	require.NoError(t, err)
 	container := restful.NewContainer().Add(ipservice)
 	machineIDTag1 := tag.MachineID + "=" + "1"

--- a/cmd/metal-api/internal/service/service.go
+++ b/cmd/metal-api/internal/service/service.go
@@ -193,7 +193,7 @@ func (e *TenantEnsurer) EnsureAllowedTenantFilter(req *restful.Request, resp *re
 	// enforce tenant check otherwise
 	tenantID := tenant(req)
 	if !e.allowed(tenantID) {
-		err := fmt.Errorf("tenant %s not allowed", tenantID)
+		err := fmt.Errorf("tenant %q not allowed", tenantID)
 		sendError(utils.Logger(req), resp, utils.CurrentFuncName(), httperrors.NewHTTPError(http.StatusForbidden, err))
 		return
 	}

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/grpc"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metrics"
-	"github.com/metal-stack/metal-lib/rest"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 	httppprof "net/http/pprof"
 	"os"
@@ -15,6 +11,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/grpc"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metrics"
+	"github.com/metal-stack/metal-lib/rest"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	nsq2 "github.com/nsqio/go-nsq"
 	"github.com/pkg/errors"
@@ -492,7 +493,7 @@ func initRestServices(withauth bool) *restfulspec.Config {
 		p = nsqer.Publisher
 		ep = nsqer.Endpoints
 	}
-	ipservice, err := service.NewIP(ds, ep, ipamer, mdc)
+	ipservice, err := service.NewIP(ds, p, ep, ipamer, mdc)
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -500,7 +501,7 @@ func initRestServices(withauth bool) *restfulspec.Config {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	fservice, err := service.NewFirewall(ds, ipamer, ep, mdc, waitServer)
+	fservice, err := service.NewFirewall(ds, p, ipamer, ep, mdc, waitServer)
 	if err != nil {
 		logger.Fatal(err)
 	}


### PR DESCRIPTION
This PR aims to mitigate errors like this:

```
...
2020-10-27 13:45:12	{"level":"info","time":"2020-10-27T12:45:12.651Z","caller":"service/machine-service.go:1574","message":"set VRF at switch","machineID":"262fa000-a9de-11e9-8000-ac1f6bd38d80"}
2020-10-27 13:45:13	{"level":"error","time":"2020-10-27T12:45:13.857Z","caller":"service/machine-service.go:1577","message":"cannot delete vrf switches","machineID":"262fa000-a9de-11e9-8000-ac1f6bd38d80","error":"cannot update switch (stg-kkw701-r01leaf01): the entity was changed from another, please retry"}
2020-10-27 13:45:13	{"level":"error","time":"2020-10-27T12:45:13.858Z","caller":"service/service.go:90","message":"service error","rqid":"a7f585fa3b7fa156173d206391049a60","remoteaddr":"10.20.2.12","method":"DELETE","uri":"/metal/v1/machine/262fa000-a9de-11e9-8000-ac1f6bd38d80/free","route":"/metal/v1/machine/{id}/free","useremail":"metal-admin@metal-stack.io","operation":"freeMachine","status":422,"error":"cannot delete vrf switches: cannot update switch (stg-kkw701-r01leaf01): the entity was changed from another, please retry","service-caller":"machine-service.go:1450","resp":"cannot delete vrf switches: cannot update switch (stg-kkw701-r01leaf01): the entity was changed from another, please retry (422)"}
2020-10-27 13:45:13	{"level":"error","time":"2020-10-27T12:45:13.858Z","caller":"rest/middleware.go:87","message":"Rest Call","rqid":"a7f585fa3b7fa156173d206391049a60","remoteaddr":"10.20.2.12","method":"DELETE","uri":"/metal/v1/machine/262fa000-a9de-11e9-8000-ac1f6bd38d80/free","route":"/metal/v1/machine/{id}/free","useremail":"metal-admin@metal-stack.io","rqid":"a7f585fa3b7fa156173d206391049a60","remoteaddr":"10.20.2.12","method":"DELETE","uri":"/metal/v1/machine/262fa000-a9de-11e9-8000-ac1f6bd38d80/free","route":"/metal/v1/machine/{id}/free","status":422,"content-length":160,"duration":1.399507635}
...
```