### PR TITLE
configurable reserve of machines per size per partition

### DIFF
--- a/cmd/metal-api/internal/metal/partition.go
+++ b/cmd/metal-api/internal/metal/partition.go
@@ -6,6 +6,7 @@ type Partition struct {
 	BootConfiguration          BootConfiguration `rethinkdb:"bootconfig" json:"bootconfig"`
 	MgmtServiceAddress         string            `rethinkdb:"mgmtserviceaddr" json:"mgmtserviceaddr"`
 	PrivateNetworkPrefixLength int               `rethinkdb:"privatenetworkprefixlength" json:"privatenetworkprefixlength"`
+	MachineReserve             MachineReserve    `rethinkdb:"machinereserve" json:"machinereserve"`
 }
 
 // BootConfiguration defines the metal-hammer initrd, kernel and commandline
@@ -14,6 +15,9 @@ type BootConfiguration struct {
 	KernelURL   string `rethinkdb:"kernelurl" json:"kernelurl"`
 	CommandLine string `rethinkdb:"commandline" json:"commandline"`
 }
+
+// MachineReserve configures spare machine size to count
+type MachineReserve map[string]int
 
 // Partitions is a list of partitions.
 type Partitions []Partition

--- a/cmd/metal-api/internal/service/partition-service.go
+++ b/cmd/metal-api/internal/service/partition-service.go
@@ -193,6 +193,12 @@ func (r partitionResource) createPartition(request *restful.Request, response *r
 	if requestPayload.PartitionBootConfiguration.CommandLine != nil {
 		commandLine = *requestPayload.PartitionBootConfiguration.CommandLine
 	}
+	var mr metal.MachineReserve
+	if requestPayload.MachineReserve != nil {
+		for k, v := range *requestPayload.MachineReserve {
+			mr[k] = v
+		}
+	}
 
 	p := &metal.Partition{
 		Base: metal.Base{
@@ -207,6 +213,7 @@ func (r partitionResource) createPartition(request *restful.Request, response *r
 			KernelURL:   kernelURL,
 			CommandLine: commandLine,
 		},
+		MachineReserve: mr,
 	}
 
 	fqn := metal.TopicMachine.GetFQN(p.GetID())
@@ -278,6 +285,13 @@ func (r partitionResource) updatePartition(request *restful.Request, response *r
 	}
 	if requestPayload.PartitionBootConfiguration.CommandLine != nil {
 		newPartition.BootConfiguration.CommandLine = *requestPayload.PartitionBootConfiguration.CommandLine
+	}
+	if requestPayload.MachineReserve != nil {
+		mr := metal.MachineReserve{}
+		for k, v := range *requestPayload.MachineReserve {
+			mr[k] = v
+		}
+		newPartition.MachineReserve = mr
 	}
 
 	err = r.ds.UpdatePartition(oldPartition, &newPartition)
@@ -361,6 +375,7 @@ func (r partitionResource) calcPartitionCapacity() ([]v1.PartitionCapacity, erro
 				cap.OtherMachines = append(cap.OtherMachines, m.ID)
 			}
 
+			cap.Reserved = p.MachineReserve[size]
 			cap.Total++
 		}
 		sc := []v1.ServerCapacity{}

--- a/cmd/metal-api/internal/service/partition-service.go
+++ b/cmd/metal-api/internal/service/partition-service.go
@@ -193,7 +193,7 @@ func (r partitionResource) createPartition(request *restful.Request, response *r
 	if requestPayload.PartitionBootConfiguration.CommandLine != nil {
 		commandLine = *requestPayload.PartitionBootConfiguration.CommandLine
 	}
-	var mr metal.MachineReserve
+	mr := metal.MachineReserve{}
 	if requestPayload.MachineReserve != nil {
 		for k, v := range *requestPayload.MachineReserve {
 			mr[k] = v

--- a/cmd/metal-api/internal/service/v1/partition.go
+++ b/cmd/metal-api/internal/service/v1/partition.go
@@ -19,12 +19,14 @@ type PartitionCreateRequest struct {
 	Common
 	PartitionBase
 	PartitionBootConfiguration PartitionBootConfiguration `json:"bootconfig" description:"the boot configuration of this partition"`
+	MachineReserve             *MachineReserve            `json:"machine_reserve,omitempty"`
 }
 
 type PartitionUpdateRequest struct {
 	Common
 	MgmtServiceAddress         *string                     `json:"mgmtserviceaddress" description:"the address to the management service of this partition" optional:"true"`
 	PartitionBootConfiguration *PartitionBootConfiguration `json:"bootconfig" description:"the boot configuration of this partition" optional:"true"`
+	MachineReserve             *MachineReserve             `json:"machine_reserve,omitempty"`
 }
 
 type PartitionResponse struct {
@@ -32,12 +34,15 @@ type PartitionResponse struct {
 	PartitionBase
 	PartitionBootConfiguration PartitionBootConfiguration `json:"bootconfig" description:"the boot configuration of this partition"`
 	Timestamps
+	MachineReserve *MachineReserve `json:"machine_reserve,omitempty"`
 }
 
 type PartitionCapacity struct {
 	Common
 	ServerCapacities []ServerCapacity `json:"servers" description:"servers available in this partition"`
 }
+
+type MachineReserve map[string]int
 
 type ServerCapacity struct {
 	Size           string   `json:"size" description:"the size of the server"`
@@ -48,11 +53,16 @@ type ServerCapacity struct {
 	FaultyMachines []string `json:"faultymachines" description:"servers with issues with this size"`
 	Other          int      `json:"other" description:"servers neither free, allocated or faulty with this size"`
 	OtherMachines  []string `json:"othermachines" description:"servers neither free, allocated or faulty with this size"`
+	Reserved       int      `json:"reserved" description:"reserved machines"`
 }
 
 func NewPartitionResponse(p *metal.Partition) *PartitionResponse {
 	if p == nil {
 		return nil
+	}
+	mr := MachineReserve{}
+	for k, v := range p.MachineReserve {
+		mr[k] = v
 	}
 	return &PartitionResponse{
 		Common: Common{
@@ -77,5 +87,6 @@ func NewPartitionResponse(p *metal.Partition) *PartitionResponse {
 			Created: p.Created,
 			Changed: p.Changed,
 		},
+		MachineReserve: &mr,
 	}
 }

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -1837,6 +1837,12 @@
         "imageid"
       ]
     },
+    "v1.MachineReserve": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
     "v1.MachineResponse": {
       "properties": {
         "allocation": {
@@ -2373,6 +2379,9 @@
           "type": "string",
           "uniqueItems": true
         },
+        "machine_reserve": {
+          "$ref": "#/definitions/v1.MachineReserve"
+        },
         "mgmtserviceaddress": {
           "description": "the address to the management service of this partition",
           "type": "string"
@@ -2421,6 +2430,9 @@
           "type": "string",
           "uniqueItems": true
         },
+        "machine_reserve": {
+          "$ref": "#/definitions/v1.MachineReserve"
+        },
         "mgmtserviceaddress": {
           "description": "the address to the management service of this partition",
           "type": "string"
@@ -2456,6 +2468,9 @@
           "description": "the unique ID of this entity",
           "type": "string",
           "uniqueItems": true
+        },
+        "machine_reserve": {
+          "$ref": "#/definitions/v1.MachineReserve"
         },
         "mgmtserviceaddress": {
           "description": "the address to the management service of this partition",
@@ -2607,6 +2622,11 @@
           },
           "type": "array"
         },
+        "reserved": {
+          "description": "reserved machines",
+          "format": "int32",
+          "type": "integer"
+        },
         "size": {
           "description": "the size of the server",
           "type": "string"
@@ -2624,6 +2644,7 @@
         "free",
         "other",
         "othermachines",
+        "reserved",
         "size",
         "total"
       ]


### PR DESCRIPTION
Currently consumers, like cluster-api, of metal-api actually just check if enough workers for the current request are available. With this approach we will end up with a situation that all workers are allocation in a partition.
But this will prevent further actions like rolling updates of worker nodes or firewalls.
To prevent this a configurable amount of machines must stay as reserved to be able to perform these updates.
The reserved machines are now configurable per size and partition.
But this implementation only performs the configuration of these reservation and does not enforce them. This enforcement is still a responsibility of the caller side.