### PR TITLE
Swagger field parentnetworkid in network response missing optional:true.

### DIFF
--- a/cmd/metal-api/internal/service/v1/network.go
+++ b/cmd/metal-api/internal/service/v1/network.go
@@ -22,7 +22,7 @@ type NetworkImmutable struct {
 	Underlay            bool     `json:"underlay" description:"if set to true, this network can be used for underlay communication"`
 	Vrf                 *uint    `json:"vrf" description:"the vrf this network is associated with" optional:"true"`
 	VrfShared           *bool    `json:"vrfshared" description:"if set to true, given vrf can be used by multiple networks, which is sometimes useful for network partioning (default: false)" optional:"true"`
-	ParentNetworkID     *string  `json:"parentnetworkid" description:"the id of the parent network"`
+	ParentNetworkID     *string  `json:"parentnetworkid" description:"the id of the parent network" optional:"true"`
 }
 
 // NetworkUsage reports core metrics about available and used IPs or Prefixes in a Network.

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -2094,7 +2094,6 @@
         "destinationprefixes",
         "id",
         "nat",
-        "parentnetworkid",
         "prefixes",
         "privatesuper",
         "underlay"
@@ -2244,7 +2243,6 @@
         "destinationprefixes",
         "id",
         "nat",
-        "parentnetworkid",
         "prefixes",
         "privatesuper",
         "underlay",


### PR DESCRIPTION
This stuff is only problematic for metal-python, it is complaining about `None` being returned by the API even though it should be a string.