### PR TITLE
Fix machine response sometimes returned incorrectly

### DIFF
--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -273,7 +273,7 @@ func NewMetalMachineHardware(r *MachineHardwareExtended) metal.MachineHardware {
 		}
 		nics = append(nics, nic)
 	}
-	var disks []metal.BlockDevice
+	disks := []metal.BlockDevice{}
 	for _, d := range r.Disks {
 		disk := metal.BlockDevice{
 			Name:    d.Name,

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -387,6 +387,7 @@ func NewMachineIPMIResponse(m *metal.Machine, s *metal.Size, p *metal.Partition,
 
 func NewMachineResponse(m *metal.Machine, s *metal.Size, p *metal.Partition, i *metal.Image, ec *metal.ProvisioningEventContainer) *MachineResponse {
 	var hardware MachineHardware
+
 	nics := MachineNics{}
 	for i := range m.Hardware.Nics {
 		nic := MachineNic{
@@ -394,23 +395,24 @@ func NewMachineResponse(m *metal.Machine, s *metal.Size, p *metal.Partition, i *
 			Name:       m.Hardware.Nics[i].Name,
 		}
 		nics = append(nics, nic)
+	}
 
-		disks := []MachineBlockDevice{}
-		for i := range m.Hardware.Disks {
-			disk := MachineBlockDevice{
-				Name: m.Hardware.Disks[i].Name,
-				Size: m.Hardware.Disks[i].Size,
-			}
-			disks = append(disks, disk)
+	disks := []MachineBlockDevice{}
+	for i := range m.Hardware.Disks {
+		disk := MachineBlockDevice{
+			Name: m.Hardware.Disks[i].Name,
+			Size: m.Hardware.Disks[i].Size,
 		}
-		hardware = MachineHardware{
-			MachineHardwareBase: MachineHardwareBase{
-				Memory:   m.Hardware.Memory,
-				CPUCores: m.Hardware.CPUCores,
-				Disks:    disks,
-			},
-			Nics: nics,
-		}
+		disks = append(disks, disk)
+	}
+
+	hardware = MachineHardware{
+		MachineHardwareBase: MachineHardwareBase{
+			Memory:   m.Hardware.Memory,
+			CPUCores: m.Hardware.CPUCores,
+			Disks:    disks,
+		},
+		Nics: nics,
 	}
 
 	var allocation *MachineAllocation

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -273,7 +273,7 @@ func NewMetalMachineHardware(r *MachineHardwareExtended) metal.MachineHardware {
 		}
 		nics = append(nics, nic)
 	}
-	disks := []metal.BlockDevice{}
+	var disks []metal.BlockDevice
 	for _, d := range r.Disks {
 		disk := metal.BlockDevice{
 			Name:    d.Name,

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -395,7 +395,7 @@ func NewMachineResponse(m *metal.Machine, s *metal.Size, p *metal.Partition, i *
 		}
 		nics = append(nics, nic)
 
-		var disks []MachineBlockDevice
+		disks := []MachineBlockDevice{}
 		for i := range m.Hardware.Disks {
 			disk := MachineBlockDevice{
 				Name: m.Hardware.Disks[i].Name,


### PR DESCRIPTION
In some cases where we have empty machines in the database (e.g. created when provisioning event was received or bmc-catcher reports a lease), we return the following response:

```
{   "id": "00000000-0000-0000-0000-ac1f6bd390a6",   "name": "",   "description": "",   "partition": null,   "rackid": "",   "size": null,   "hardware": {    "memory":
0,    "cpu_cores": 0,    "disks": null,    "nics": null   }
```

According to our spec though we do not return `null` for `disks` or `nics`.