### PR TITLE
emit PlannedReboot event on machine deletion

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1458,6 +1458,12 @@ func (r machineResource) freeMachine(request *restful.Request, response *restful
 	if err != nil {
 		logger.Error("Failed to send response", zap.Error(err))
 	}
+
+	event := string(metal.ProvisioningEventPlannedReboot)
+	_, err = r.provisioningEventForMachine(id, v1.MachineProvisioningEvent{Time: time.Now(), Event: event, Message: "freeMachine"})
+	if checkError(request, response, utils.CurrentFuncName(), err) {
+		return
+	}
 }
 
 // reinstallMachine reinstalls the requested machine with given image by either allocating


### PR DESCRIPTION
fixes https://github.com/metal-stack/metal-api/issues/127

```
$ metalctl machine destroy e0ab02d2-27cd-5a5e-8efc-080ba80cf258
ID                                                      LAST EVENT      WHEN    AGE     HOSTNAME        PROJECT SIZE            IMAGE   PARTITION
e0ab02d2-27cd-5a5e-8efc-080ba80cf258                    Phoned Home     53s                                     v1-small-x86            vagrant

$ metalctl machine ls
ID                                                      LAST EVENT      WHEN    AGE     HOSTNAME        PROJECT SIZE            IMAGE   PARTITION
e0ab02d2-27cd-5a5e-8efc-080ba80cf258                    Planned Reboot  2s                                      v1-small-x86            vagrant
2294c949-88f6-5390-8154-fa53d93a3313                    Waiting         5s                                      v1-small-x86            vagrant
```