### PR TITLE
Introduce UUIDs for IP allocations.

### DIFF
--- a/cmd/metal-api/internal/datastore/ip.go
+++ b/cmd/metal-api/internal/datastore/ip.go
@@ -1,6 +1,9 @@
 package datastore
 
 import (
+	"fmt"
+
+	"github.com/google/uuid"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 	"github.com/metal-stack/metal-lib/pkg/tag"
 	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
@@ -88,6 +91,13 @@ func (rs *RethinkStore) ListIPs() (metal.IPs, error) {
 
 // CreateIP creates a new ip.
 func (rs *RethinkStore) CreateIP(ip *metal.IP) error {
+	if ip.AllocationUUID == "" {
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			return fmt.Errorf("unable to create uuid for IP allocation: %v", err)
+		}
+		ip.AllocationUUID = uuid.String()
+	}
 	return rs.createEntity(rs.ipTable(), ip)
 }
 

--- a/cmd/metal-api/internal/datastore/migrations/02_ip_uuids.go
+++ b/cmd/metal-api/internal/datastore/migrations/02_ip_uuids.go
@@ -1,0 +1,40 @@
+package migrations
+
+import (
+	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
+
+	"github.com/google/uuid"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
+)
+
+func init() {
+	datastore.MustRegisterMigration(datastore.Migration{
+		Name:    "generate allocation uuids for new ip address field (#70)",
+		Version: 2,
+		Up: func(db *r.Term, session r.QueryExecutor, rs *datastore.RethinkStore) error {
+			ips, err := rs.ListIPs()
+			if err != nil {
+				return err
+			}
+
+			for _, old := range ips {
+				if old.AllocationUUID != "" {
+					continue
+				}
+
+				uuid, err := uuid.NewRandom()
+				if err != nil {
+					return err
+				}
+
+				new := old
+				new.AllocationUUID = uuid.String()
+				err = rs.UpdateIP(&old, &new)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/cmd/metal-api/internal/metal/ip.go
+++ b/cmd/metal-api/internal/metal/ip.go
@@ -35,7 +35,12 @@ const (
 
 // IP of a machine/firewall.
 type IP struct {
-	IPAddress        string    `rethinkdb:"id" json:"id"`
+	IPAddress string `rethinkdb:"id" json:"id"`
+	// AllocationID will be randomly generated during IP creation and helps identifying the point in time
+	// when an IP was created.
+	// Without this field it is impossible to distinguish whether an IP address was re-acquired or
+	// if it is still the same ip address as before.
+	AllocationUUID   string    `rethinkdb:"allocationuuid" json:"allocationuuid"`
 	ParentPrefixCidr string    `rethinkdb:"prefix" json:"prefix"`
 	Name             string    `rethinkdb:"name" json:"name"`
 	Description      string    `rethinkdb:"description" json:"description"`

--- a/cmd/metal-api/internal/metal/ip.go
+++ b/cmd/metal-api/internal/metal/ip.go
@@ -37,8 +37,8 @@ const (
 type IP struct {
 	IPAddress string `rethinkdb:"id" json:"id"`
 	// AllocationID will be randomly generated during IP creation and helps identifying the point in time
-	// when an IP was created.
-	// Without this field it is impossible to distinguish whether an IP address was re-acquired or
+	// when an IP was created. This is not the primary key!
+	// This field can help to distinguish whether an IP address was re-acquired or
 	// if it is still the same ip address as before.
 	AllocationUUID   string    `rethinkdb:"allocationuuid" json:"allocationuuid"`
 	ParentPrefixCidr string    `rethinkdb:"prefix" json:"prefix"`

--- a/cmd/metal-api/internal/service/v1/ip.go
+++ b/cmd/metal-api/internal/service/v1/ip.go
@@ -13,7 +13,8 @@ type IPBase struct {
 }
 
 type IPIdentifiable struct {
-	IPAddress string `json:"ipaddress" modelDescription:"an ip address that can be attached to a machine" description:"the address (ipv4 or ipv6) of this ip" unique:"true" readonly:"true"`
+	IPAddress      string `json:"ipaddress" modelDescription:"an ip address that can be attached to a machine" description:"the address (ipv4 or ipv6) of this ip" unique:"true" readonly:"true"`
+	AllocationUUID string `json:"allocationuuid" description:"a unique identifier for this ip address allocation, can be used for distinguishing between ip address allocation over time." readonly:"true"`
 }
 
 type IPAllocateRequest struct {
@@ -57,7 +58,8 @@ func NewIPResponse(ip *metal.IP) *IPResponse {
 			Tags:      tags,
 		},
 		IPIdentifiable: IPIdentifiable{
-			IPAddress: ip.IPAddress,
+			IPAddress:      ip.IPAddress,
+			AllocationUUID: ip.AllocationUUID,
 		},
 		Timestamps: Timestamps{
 			Created: ip.Created,

--- a/cmd/metal-api/internal/service/v1/ip.go
+++ b/cmd/metal-api/internal/service/v1/ip.go
@@ -14,7 +14,7 @@ type IPBase struct {
 
 type IPIdentifiable struct {
 	IPAddress      string `json:"ipaddress" modelDescription:"an ip address that can be attached to a machine" description:"the address (ipv4 or ipv6) of this ip" unique:"true" readonly:"true"`
-	AllocationUUID string `json:"allocationuuid" description:"a unique identifier for this ip address allocation, can be used for distinguishing between ip address allocation over time." readonly:"true"`
+	AllocationUUID string `json:"allocationuuid" description:"a unique identifier for this ip address allocation, can be used to distinguish between ip address allocation over time." readonly:"true"`
 }
 
 type IPAllocateRequest struct {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-stack/stack v1.8.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4
+	github.com/google/uuid v1.1.2
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -573,6 +573,10 @@
     },
     "v1.IPResponse": {
       "properties": {
+        "allocationuuid": {
+          "description": "a unique identifier for this ip address allocation, can be used for distinguishing between ip address allocation over time.",
+          "type": "string"
+        },
         "changed": {
           "description": "the last changed timestamp of this entity",
           "format": "date-time",
@@ -624,6 +628,7 @@
         }
       },
       "required": [
+        "allocationuuid",
         "ipaddress",
         "networkid",
         "projectid",
@@ -632,6 +637,10 @@
     },
     "v1.IPUpdateRequest": {
       "properties": {
+        "allocationuuid": {
+          "description": "a unique identifier for this ip address allocation, can be used for distinguishing between ip address allocation over time.",
+          "type": "string"
+        },
         "description": {
           "description": "a description for this entity",
           "type": "string"
@@ -662,6 +671,7 @@
         }
       },
       "required": [
+        "allocationuuid",
         "ipaddress",
         "type"
       ]


### PR DESCRIPTION
They are not the primary key in the database. Can be used for distinguishing between ip address allocation over time.