### PR TITLE
Add data store connect opts.

### DIFF
--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -115,7 +115,7 @@ func (ip *IntegerPool) String() string {
 func (ip *IntegerPool) initIntegerPool(log *zap.SugaredLogger) error {
 	var result integerinfo
 	err := ip.infoTable.ReadOne(&result, ip.session)
-	if err != nil {
+	if err != nil && err != r.ErrEmptyResult {
 		return err
 	}
 

--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -106,7 +106,7 @@ func (rs *RethinkStore) GetASNPool() *IntegerPool {
 // - everything can be done atomically, so there are no race conditions
 func (ip *IntegerPool) initIntegerPool(rs *RethinkStore) error {
 	var result integerinfo
-	err := rs.findEntityByID(ip.table(rs), &result, ip.tablename)
+	err := rs.findEntityByID(ip.infoTable(rs), &result, ip.tablename)
 	if err != nil {
 		if !metal.IsNotFound(err) {
 			return err
@@ -124,7 +124,7 @@ func (ip *IntegerPool) initIntegerPool(rs *RethinkStore) error {
 	if err != nil {
 		return err
 	}
-	_, err = ip.table(rs).Insert(map[string]interface{}{"id": ip.tablename, "IsInitialized": true}).RunWrite(rs.session)
+	_, err = ip.infoTable(rs).Insert(map[string]interface{}{"id": ip.tablename, "IsInitialized": true}).RunWrite(rs.session)
 	return err
 }
 

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -84,8 +84,7 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip, err := rs.GetIntegerPool(VRFIntegerPool)
-			assert.NoError(t, err)
+			ip := rs.GetVRFPool()
 			if tt.requiresMock {
 				if tt.err != nil {
 					mock.On(r.DB("mockdb").Table(ip.tablename).Insert(integer{ID: tt.value}, r.InsertOpts{Conflict: "replace"})).Return(nil, tt.err)
@@ -112,8 +111,7 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 
 func TestRethinkStore_AcquireRandomUniqueInteger(t *testing.T) {
 	rs, mock := InitMockDB()
-	ip, err := rs.GetIntegerPool(VRFIntegerPool)
-	assert.NoError(t, err)
+	ip := rs.GetVRFPool()
 	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(VRFPoolRangeMin)}}}
 	mock.On(r.DB("mockdb").Table(ip.tablename).Limit(1).Delete(r.
 		DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes}, nil)
@@ -149,8 +147,7 @@ func TestRethinkStore_AcquireUniqueInteger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip, err := rs.GetIntegerPool(VRFIntegerPool)
-			assert.NoError(t, err)
+			ip := rs.GetVRFPool()
 
 			if tt.requiresMock {
 				changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(
@@ -216,8 +213,7 @@ func TestRethinkStore_genericAcquire(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs, mock := InitMockDB()
-			ip, err := rs.GetIntegerPool(VRFIntegerPool)
-			assert.NoError(t, err)
+			ip := rs.GetVRFPool()
 
 			term := rs.integerTable(ip.tablename).Get(tt.value)
 			if tt.requiresMock {

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -215,7 +215,7 @@ func TestRethinkStore_genericAcquire(t *testing.T) {
 			rs, mock := InitMockDB()
 			ip := rs.GetVRFPool()
 
-			term := rs.integerTable(ip.tablename).Get(tt.value)
+			term := ip.table(rs).Get(tt.value)
 			if tt.requiresMock {
 				var changes []r.ChangeResponse
 				if tt.tableChanges {
@@ -225,7 +225,7 @@ func TestRethinkStore_genericAcquire(t *testing.T) {
 				mock.On(term.Delete(r.DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes},
 					tt.runWriteErr)
 				if tt.requiresCountMock {
-					mock.On(rs.integerTable(ip.tablename).Count()).Return(int64(0), nil)
+					mock.On(ip.table(rs).Count()).Return(int64(0), nil)
 				}
 			}
 

--- a/cmd/metal-api/internal/datastore/integer_test.go
+++ b/cmd/metal-api/internal/datastore/integer_test.go
@@ -87,9 +87,9 @@ func TestRethinkStore_ReleaseUniqueInteger(t *testing.T) {
 			ip := rs.GetVRFPool()
 			if tt.requiresMock {
 				if tt.err != nil {
-					mock.On(r.DB("mockdb").Table(ip.tablename).Insert(integer{ID: tt.value}, r.InsertOpts{Conflict: "replace"})).Return(nil, tt.err)
+					mock.On(r.DB("mockdb").Table(ip.String()).Insert(integer{ID: tt.value}, r.InsertOpts{Conflict: "replace"})).Return(nil, tt.err)
 				} else {
-					mock.On(r.DB("mockdb").Table(ip.tablename).Insert(integer{ID: tt.value}, r.InsertOpts{Conflict: "replace"})).Return(r.
+					mock.On(r.DB("mockdb").Table(ip.String()).Insert(integer{ID: tt.value}, r.InsertOpts{Conflict: "replace"})).Return(r.
 						WriteResponse{Changes: []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(
 						tt.value)}}}}, tt.err)
 				}
@@ -113,7 +113,7 @@ func TestRethinkStore_AcquireRandomUniqueInteger(t *testing.T) {
 	rs, mock := InitMockDB()
 	ip := rs.GetVRFPool()
 	changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(VRFPoolRangeMin)}}}
-	mock.On(r.DB("mockdb").Table(ip.tablename).Limit(1).Delete(r.
+	mock.On(r.DB("mockdb").Table(ip.String()).Limit(1).Delete(r.
 		DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes}, nil)
 
 	got, err := ip.AcquireRandomUniqueInteger()
@@ -152,7 +152,7 @@ func TestRethinkStore_AcquireUniqueInteger(t *testing.T) {
 			if tt.requiresMock {
 				changes := []r.ChangeResponse{{OldValue: map[string]interface{}{"id": float64(
 					tt.value)}}}
-				mock.On(r.DB("mockdb").Table(ip.tablename).Get(tt.value).Delete(r.
+				mock.On(r.DB("mockdb").Table(ip.String()).Get(tt.value).Delete(r.
 					DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes}, tt.err)
 			}
 
@@ -215,7 +215,7 @@ func TestRethinkStore_genericAcquire(t *testing.T) {
 			rs, mock := InitMockDB()
 			ip := rs.GetVRFPool()
 
-			term := ip.table(rs).Get(tt.value)
+			term := ip.poolTable.Get(tt.value)
 			if tt.requiresMock {
 				var changes []r.ChangeResponse
 				if tt.tableChanges {
@@ -225,7 +225,7 @@ func TestRethinkStore_genericAcquire(t *testing.T) {
 				mock.On(term.Delete(r.DeleteOpts{ReturnChanges: true})).Return(r.WriteResponse{Changes: changes},
 					tt.runWriteErr)
 				if tt.requiresCountMock {
-					mock.On(ip.table(rs).Count()).Return(int64(0), nil)
+					mock.On(ip.poolTable.Count()).Return(int64(0), nil)
 				}
 			}
 

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -170,24 +170,8 @@ func (rs *RethinkStore) asnTable() *r.Term {
 	res := r.DB(rs.dbname).Table(ASNIntegerPool.String())
 	return &res
 }
-func (rs *RethinkStore) asnInfoTable() *r.Term {
-	res := r.DB(rs.dbname).Table(ASNIntegerPool.String() + "info")
-	return &res
-}
 func (rs *RethinkStore) vrfTable() *r.Term {
 	res := r.DB(rs.dbname).Table(VRFIntegerPool.String())
-	return &res
-}
-func (rs *RethinkStore) vrfInfoTable() *r.Term {
-	res := r.DB(rs.dbname).Table(VRFIntegerPool.String() + "info")
-	return &res
-}
-func (rs *RethinkStore) integerTable(tableName string) *r.Term {
-	res := r.DB(rs.dbname).Table(tableName)
-	return &res
-}
-func (rs *RethinkStore) integerInfoTable(tableName string) *r.Term {
-	res := r.DB(rs.dbname).Table(tableName + "info")
 	return &res
 }
 func (rs *RethinkStore) migrationTable() *r.Term {

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -66,8 +66,8 @@ func (rs *RethinkStore) Health() error {
 	)
 }
 
-// Initialize initializes the database, it should be called every time
-// the application comes up before using the data store
+// Initialize initializes the database, it should be called before serving the metal-api
+// in order to ensure that tables, pools, permissions are properly initialized
 func (rs *RethinkStore) Initialize() error {
 	return rs.initializeTables(r.TableCreateOpts{Shards: 1, Replicas: 1})
 }

--- a/cmd/metal-api/internal/datastore/rethinkdb.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb.go
@@ -119,12 +119,12 @@ func (rs *RethinkStore) initializeTables(opts r.TableCreateOpts) error {
 	}
 
 	// integer pools
-	err = rs.GetVRFPool().initIntegerPool(rs)
+	err = rs.GetVRFPool().initIntegerPool(rs.SugaredLogger)
 	if err != nil {
 		return err
 	}
 
-	err = rs.GetASNPool().initIntegerPool(rs)
+	err = rs.GetASNPool().initIntegerPool(rs.SugaredLogger)
 	if err != nil {
 		return err
 	}
@@ -170,8 +170,16 @@ func (rs *RethinkStore) asnTable() *r.Term {
 	res := r.DB(rs.dbname).Table(ASNIntegerPool.String())
 	return &res
 }
+func (rs *RethinkStore) asnInfoTable() *r.Term {
+	res := r.DB(rs.dbname).Table(ASNIntegerPool.String() + "info")
+	return &res
+}
 func (rs *RethinkStore) vrfTable() *r.Term {
 	res := r.DB(rs.dbname).Table(VRFIntegerPool.String())
+	return &res
+}
+func (rs *RethinkStore) vrfInfoTable() *r.Term {
+	res := r.DB(rs.dbname).Table(VRFIntegerPool.String() + "info")
 	return &res
 }
 func (rs *RethinkStore) migrationTable() *r.Term {

--- a/cmd/metal-api/internal/datastore/rethinkdb_test.go
+++ b/cmd/metal-api/internal/datastore/rethinkdb_test.go
@@ -17,7 +17,6 @@ var (
 		dbname:        "dbname",
 		dbuser:        "dbuser",
 		dbpass:        "password",
-		integerPools:  make(map[IntegerPoolType]*IntegerPool),
 	}
 )
 

--- a/cmd/metal-api/internal/datastore/testing.go
+++ b/cmd/metal-api/internal/datastore/testing.go
@@ -34,12 +34,6 @@ func InitMockDB() (*RethinkStore, *r.Mock) {
 		"db-password",
 	)
 	mock := rs.Mock()
-	vrfterm := rs.integerTable(VRFIntegerPool.String())
-	asnterm := rs.integerTable(VRFIntegerPool.String())
-	vrfPool := IntegerPool{tablename: VRFIntegerPool.String(), min: VRFPoolRangeMin, max: VRFPoolRangeMax, term: vrfterm, session: rs.session}
-	asnPool := IntegerPool{tablename: ASNIntegerPool.String(), min: ASNPoolRangeMin, max: ASNPoolRangeMax, term: asnterm, session: rs.session}
-	rs.integerPools[VRFIntegerPool] = &vrfPool
-	rs.integerPools[ASNIntegerPool] = &asnPool
 	return rs, mock
 }
 

--- a/cmd/metal-api/internal/service/asn.go
+++ b/cmd/metal-api/internal/service/asn.go
@@ -21,11 +21,7 @@ const (
 
 // acquireASN fetches a unique integer by using the existing integer pool and adding to ASNBase
 func acquireASN(ds *datastore.RethinkStore) (*uint32, error) {
-	asnPool, err := ds.GetIntegerPool(datastore.ASNIntegerPool)
-	if err != nil {
-		return nil, err
-	}
-	i, err := asnPool.AcquireRandomUniqueInteger()
+	i, err := ds.GetASNPool().AcquireRandomUniqueInteger()
 	if err != nil {
 		return nil, err
 	}
@@ -43,9 +39,5 @@ func releaseASN(ds *datastore.RethinkStore, asn uint32) error {
 	}
 	i := uint(asn - ASNBase)
 
-	asnPool, err := ds.GetIntegerPool(datastore.ASNIntegerPool)
-	if err != nil {
-		return err
-	}
-	return asnPool.ReleaseUniqueInteger(i)
+	return ds.GetASNPool().ReleaseUniqueInteger(i)
 }

--- a/cmd/metal-api/internal/service/vrf.go
+++ b/cmd/metal-api/internal/service/vrf.go
@@ -1,36 +1,22 @@
 package service
 
 import (
-	"fmt"
-
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
 )
 
 // acquireRandomVRF will grab a unique but random vrf out of the vrfintegerpool
 func acquireRandomVRF(ds *datastore.RethinkStore) (*uint, error) {
-	vrfPool, err := ds.GetIntegerPool(datastore.VRFIntegerPool)
-	if err != nil {
-		return nil, fmt.Errorf("could not acquire random vrf: %v", err)
-	}
-	vrf, err := vrfPool.AcquireRandomUniqueInteger()
+	vrf, err := ds.GetVRFPool().AcquireRandomUniqueInteger()
 	return &vrf, err
 }
 
 // acquireVRF will the given vrf out of the vrfintegerpool if not available a error is thrown
 func acquireVRF(ds *datastore.RethinkStore, vrf uint) error {
-	vrfPool, err := ds.GetIntegerPool(datastore.VRFIntegerPool)
-	if err != nil {
-		return fmt.Errorf("could not acquire vrf:%d %v", vrf, err)
-	}
-	_, err = vrfPool.AcquireUniqueInteger(vrf)
+	_, err := ds.GetVRFPool().AcquireUniqueInteger(vrf)
 	return err
 }
 
 // releaseVRF will return the given vrf to the vrfintegerpool for reuse
 func releaseVRF(ds *datastore.RethinkStore, vrf uint) error {
-	vrfPool, err := ds.GetIntegerPool(datastore.VRFIntegerPool)
-	if err != nil {
-		return fmt.Errorf("could not release vrf: %v", err)
-	}
-	return vrfPool.ReleaseUniqueInteger(vrf)
+	return ds.GetVRFPool().ReleaseUniqueInteger(vrf)
 }

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -130,12 +130,7 @@ var initDatabase = &cobra.Command{
 	Short:   "initializes the database with all tables and indices",
 	Version: v.V.String(),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := connectDataStore(DataStoreConnectTableInit, DataStoreConnectNoDemotion)
-		if err != nil {
-			return err
-		}
-
-		return ds.Initialize()
+		return connectDataStore(DataStoreConnectTableInit, DataStoreConnectNoDemotion)
 	},
 }
 

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -54,7 +54,7 @@ const (
 
 	// DataStoreConnectTableInit connects to the data store and then runs data store initialization
 	DataStoreConnectTableInit dsConnectOpt = 0
-	// DataStoreConnectNoDemotion connects to the data store without demoting to runtime user
+	// DataStoreConnectNoDemotion connects to the data store without demoting to runtime user in the end
 	DataStoreConnectNoDemotion dsConnectOpt = 1
 )
 


### PR DESCRIPTION
The intention is to run database initialization or the database admin user only when it's required.

Running database initialization always can be problematic when scenarios like the following occur:

- The rethinkdb does not come during the deployment for some reason
- Commands from cron jobs like evaluateMachineLiveliness, resurrectDeadMachines, ... queue up in Kubernetes
- When the database comes up all the pods start execution at the same time
- If there was a change in the tables, it can happen that tables are created multiple times -> Rethinkdb is broken

Generally, we should configure the deployment such that only the init-db pre-deployment-hook initializes the database because the hook is guaranteed to only run one at a time.

Also, all tasks should do user demotion, but for the db-init command and the migrate command this is not required because they do not affect possible migrations while running.