### PR TITLE
Declare last event time as optional in swagger spec.

### DIFF
--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -105,7 +105,7 @@ type MachineBlockDevice struct {
 
 type MachineRecentProvisioningEvents struct {
 	Events                       []MachineProvisioningEvent `json:"log" description:"the log of recent machine provisioning events"`
-	LastEventTime                *time.Time                 `json:"last_event_time" description:"the time where the last event was received"`
+	LastEventTime                *time.Time                 `json:"last_event_time" description:"the time where the last event was received" optional:"true"`
 	IncompleteProvisioningCycles string                     `json:"incomplete_provisioning_cycles" description:"the amount of incomplete provisioning cycles in the event container"`
 }
 

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -574,7 +574,7 @@
     "v1.IPResponse": {
       "properties": {
         "allocationuuid": {
-          "description": "a unique identifier for this ip address allocation, can be used for distinguishing between ip address allocation over time.",
+          "description": "a unique identifier for this ip address allocation, can be used to distinguish between ip address allocation over time.",
           "type": "string"
         },
         "changed": {
@@ -638,7 +638,7 @@
     "v1.IPUpdateRequest": {
       "properties": {
         "allocationuuid": {
-          "description": "a unique identifier for this ip address allocation, can be used for distinguishing between ip address allocation over time.",
+          "description": "a unique identifier for this ip address allocation, can be used to distinguish between ip address allocation over time.",
           "type": "string"
         },
         "description": {
@@ -1780,7 +1780,6 @@
       },
       "required": [
         "incomplete_provisioning_cycles",
-        "last_event_time",
         "log"
       ]
     },


### PR DESCRIPTION
Makes python client happier.