### PR TITLE
Make IPs searchable by name.

### DIFF
--- a/cmd/metal-api/internal/datastore/ip.go
+++ b/cmd/metal-api/internal/datastore/ip.go
@@ -12,6 +12,7 @@ import (
 // IPSearchQuery can be used to search networks.
 type IPSearchQuery struct {
 	IPAddress        *string  `json:"ipaddress" modelDescription:"an ip address that can be attached to a machine" description:"the address (ipv4 or ipv6) of this ip" optional:"true"`
+	Name             *string  `json:"name" description:"the name of the ip address" optional:"true"`
 	ParentPrefixCidr *string  `json:"networkprefix" description:"the prefix of the network this ip address belongs to" optional:"true"`
 	NetworkID        *string  `json:"networkid" description:"the network this ip allocate request address belongs to" optional:"true"`
 	Tags             []string `json:"tags" description:"the tags that are assigned to this ip address" optional:"true"`
@@ -27,6 +28,12 @@ func (p *IPSearchQuery) generateTerm(rs *RethinkStore) *r.Term {
 	if p.IPAddress != nil {
 		q = q.Filter(func(row r.Term) r.Term {
 			return row.Field("id").Eq(*p.IPAddress)
+		})
+	}
+
+	if p.Name != nil {
+		q = q.Filter(func(row r.Term) r.Term {
+			return row.Field("name").Eq(*p.Name)
 		})
 	}
 

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -546,6 +546,10 @@
           "description": "the machine an ip address is associated to",
           "type": "string"
         },
+        "name": {
+          "description": "the name of the ip address",
+          "type": "string"
+        },
         "networkid": {
           "description": "the network this ip allocate request address belongs to",
           "type": "string"


### PR DESCRIPTION
Closes #151.

This will be a pretty nice feature for our metal-ansible-modules because it allows to implement CRUD IPs by names. This way, you can write up an automation without having to allocate static IPs before a deployment (modules will enforce name uniqueness for IPs during the run).