### PR TITLE
Detect failed machine reclaim

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1792,8 +1792,8 @@ func (r machineResource) provisioningEventForMachine(machineID string, e v1.Mach
 		} else {
 			ec.Events = append([]metal.ProvisioningEvent{event}, ec.Events...)
 			ec.IncompleteProvisioningCycles = ec.CalculateIncompleteCycles(zapup.MustRootLogger().Sugar())
+			ec.Liveliness = metal.MachineLivelinessAlive
 		}
-		ec.Liveliness = metal.MachineLivelinessAlive
 	}
 	ec.TrimEvents(metal.ProvisioningEventsInspectionLimit)
 


### PR DESCRIPTION
Detects a machine state described in #166 where machine reclaim did not work (allocation is gone, still phoning home, but restart does not happen). 

This state can easily be created in the mini-lab because where we do not have a BMC. A user has to manually restart the machine to boot it back into the metal-hammer. Effectively though, a user could also still use the machine, which is something we should prevent. So, this state helps operations to identify such machines.

Looks like this in the mini-lab:

``` 
m machine ls
ID                                                      LAST EVENT      WHEN    AGE     HOSTNAME        PROJECT SIZE            IMAGE   PARTITION 
e0ab02d2-27cd-5a5e-8efc-080ba80cf258                    Waiting         35s                                     v1-small-x86            vagrant  
2294c949-88f6-5390-8154-fa53d93a3313            ❓      Planned Reboot  9s                                      v1-small-x86            vagrant  
```