### PR TITLE
Improve performance by using errors.New rather than fmt.Errorf where …

### DIFF
--- a/cmd/metal-api/internal/datastore/image.go
+++ b/cmd/metal-api/internal/datastore/image.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -170,7 +171,7 @@ func (rs *RethinkStore) getMostRecentImageFor(id string, images metal.Images) (*
 func GetOsAndSemver(id string) (string, *semver.Version, error) {
 	imageParts := strings.Split(id, "-")
 	if len(imageParts) < 2 {
-		return "", nil, fmt.Errorf("image does not contain a version")
+		return "", nil, errors.New("image does not contain a version")
 	}
 
 	parts := len(imageParts) - 1

--- a/cmd/metal-api/internal/datastore/integer.go
+++ b/cmd/metal-api/internal/datastore/integer.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
@@ -195,7 +196,7 @@ func (ip *IntegerPool) genericAcquire(term *r.Term) (uint, error) {
 		}
 
 		if count <= 0 {
-			return 0, metal.Internal(fmt.Errorf("acquisition of a value failed for exhausted pool"), "")
+			return 0, metal.Internal(errors.New("acquisition of a value failed for exhausted pool"), "")
 		}
 		return 0, metal.Conflict("integer is already acquired by another")
 	}

--- a/cmd/metal-api/internal/datastore/machine.go
+++ b/cmd/metal-api/internal/datastore/machine.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 
@@ -468,7 +469,7 @@ func (rs *RethinkStore) FindWaitingMachine(partitionid, sizeid string) (*metal.M
 	}
 
 	if available == nil || len(available) < 1 {
-		return nil, fmt.Errorf("no machine available")
+		return nil, errors.New("no machine available")
 	}
 
 	// pick a random machine from all available ones

--- a/cmd/metal-api/internal/datastore/migrate.go
+++ b/cmd/metal-api/internal/datastore/migrate.go
@@ -76,7 +76,7 @@ func (ms Migrations) Between(current int, target *int) (Migrations, error) {
 	})
 
 	if target != nil && !targetFound {
-		return nil, fmt.Errorf("target version not found")
+		return nil, errors.New("target version not found")
 	}
 
 	return result, nil

--- a/cmd/metal-api/internal/datastore/size.go
+++ b/cmd/metal-api/internal/datastore/size.go
@@ -1,8 +1,7 @@
 package datastore
 
 import (
-	"fmt"
-
+	"errors"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
@@ -46,7 +45,7 @@ func (rs *RethinkStore) FromHardware(hw metal.MachineHardware) (*metal.Size, []*
 	}
 	if len(sz) < 1 {
 		// this should not happen, so we do not return a notfound
-		return nil, nil, fmt.Errorf("no sizes found in database")
+		return nil, nil, errors.New("no sizes found in database")
 	}
 	var sizes []metal.Size
 	for _, s := range sz {

--- a/cmd/metal-api/internal/metal/errors.go
+++ b/cmd/metal-api/internal/metal/errors.go
@@ -1,16 +1,14 @@
 package metal
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 )
 
 var (
-	errNotFound = fmt.Errorf("NotFound")
-	errConflict = fmt.Errorf("Conflict")
+	errNotFound = errors.New("NotFound")
+	errConflict = errors.New("Conflict")
 	// TODO refactor implentations of fmt.Errorf to metal.Internal() in datastore and service
-	errInternal = fmt.Errorf("Internal")
+	errInternal = errors.New("Internal")
 )
 
 // NotFound creates a new notfound error with a given error message.

--- a/cmd/metal-api/internal/service/async-actor.go
+++ b/cmd/metal-api/internal/service/async-actor.go
@@ -41,7 +41,7 @@ func newAsyncActor(l *zap.Logger, ep *bus.Endpoints, ds *datastore.RethinkStore,
 
 func (a *asyncActor) freeMachine(pub bus.Publisher, m *metal.Machine) error {
 	if m.State.Value == metal.LockedState {
-		return fmt.Errorf("machine is locked")
+		return errors.New("machine is locked")
 	}
 
 	err := deleteVRFSwitches(a.RethinkStore, m, a.Logger)
@@ -142,9 +142,9 @@ func (a *asyncActor) disassociateIP(ip *metal.IP, machine *metal.Machine) error 
 	}
 
 	// disassociate machine from ip
-	new := *ip
-	new.RemoveMachineId(machine.GetID())
-	err := a.UpdateIP(ip, &new)
+	newIP := *ip
+	newIP.RemoveMachineId(machine.GetID())
+	err := a.UpdateIP(ip, &newIP)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (a *asyncActor) disassociateIP(ip *metal.IP, machine *metal.Machine) error 
 		return nil
 	}
 	// ips that are associated to other machines will should not be released automatically
-	if len(new.GetMachineIds()) > 0 {
+	if len(newIP.GetMachineIds()) > 0 {
 		return nil
 	}
 

--- a/cmd/metal-api/internal/service/firewall-service.go
+++ b/cmd/metal-api/internal/service/firewall-service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -122,7 +123,7 @@ func (r firewallResource) findFirewall(request *restful.Request, response *restf
 	}
 
 	if !fw.IsFirewall(imgs.ByID()) {
-		sendError(utils.Logger(request), response, utils.CurrentFuncName(), httperrors.NotFound(fmt.Errorf("machine is not a firewall")))
+		sendError(utils.Logger(request), response, utils.CurrentFuncName(), httperrors.NotFound(errors.New("machine is not a firewall")))
 		return
 	}
 
@@ -221,7 +222,7 @@ func (r firewallResource) allocateFirewall(request *restful.Request, response *r
 		userdata = *requestPayload.UserData
 	}
 	if requestPayload.Networks != nil && len(requestPayload.Networks) <= 0 {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("network ids cannot be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("network ids cannot be empty")) {
 			return
 		}
 	}
@@ -230,7 +231,7 @@ func (r firewallResource) allocateFirewall(request *restful.Request, response *r
 		ha = *requestPayload.HA
 	}
 	if ha {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("highly-available firewall not supported for the time being")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("highly-available firewall not supported for the time being")) {
 			return
 		}
 	}

--- a/cmd/metal-api/internal/service/image-service.go
+++ b/cmd/metal-api/internal/service/image-service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -174,13 +175,13 @@ func (ir imageResource) createImage(request *restful.Request, response *restful.
 	}
 
 	if requestPayload.ID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("id should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("id should not be empty")) {
 			return
 		}
 	}
 
 	if requestPayload.URL == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("url should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("url should not be empty")) {
 			return
 		}
 	}

--- a/cmd/metal-api/internal/service/ip-service.go
+++ b/cmd/metal-api/internal/service/ip-service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -212,7 +213,7 @@ func (ir ipResource) freeIP(request *restful.Request, response *restful.Response
 func validateIPDelete(ip *metal.IP) error {
 	s := ip.GetScope()
 	if s == metal.ScopeMachine {
-		return fmt.Errorf("ip with machine scope can not be deleted")
+		return errors.New("ip with machine scope can not be deleted")
 	}
 	return nil
 }
@@ -225,7 +226,7 @@ func validateIPDelete(ip *metal.IP) error {
 func validateIPUpdate(old *metal.IP, new *metal.IP) error {
 	// constraint 1
 	if old.Type == metal.Static && new.Type == metal.Ephemeral {
-		return fmt.Errorf("cannot change type of ip address from static to ephemeral")
+		return errors.New("cannot change type of ip address from static to ephemeral")
 	}
 	os := old.GetScope()
 	ns := new.GetScope()
@@ -254,12 +255,12 @@ func (ir ipResource) allocateIP(request *restful.Request, response *restful.Resp
 	}
 
 	if requestPayload.NetworkID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("networkid should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("networkid should not be empty")) {
 			return
 		}
 	}
 	if requestPayload.ProjectID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("projectid should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("projectid should not be empty")) {
 			return
 		}
 	}
@@ -396,7 +397,7 @@ func (ir ipResource) validateAndUpateIP(oldIP, newIP *metal.IP) error {
 }
 
 func allocateIP(parent *metal.Network, specificIP string, ipamer ipam.IPAMer) (string, string, error) {
-	var errors []error
+	var ee []error
 	var err error
 	var ipAddress string
 	var parentPrefixCidr string
@@ -407,7 +408,7 @@ func allocateIP(parent *metal.Network, specificIP string, ipamer ipam.IPAMer) (s
 			ipAddress, err = ipamer.AllocateSpecificIP(prefix, specificIP)
 		}
 		if err != nil {
-			errors = append(errors, err)
+			ee = append(ee, err)
 			continue
 		}
 		if ipAddress != "" {
@@ -416,10 +417,10 @@ func allocateIP(parent *metal.Network, specificIP string, ipamer ipam.IPAMer) (s
 		}
 	}
 	if ipAddress == "" {
-		if len(errors) > 0 {
-			return "", "", fmt.Errorf("cannot allocate free ip in ipam: %v", errors)
+		if len(ee) > 0 {
+			return "", "", fmt.Errorf("cannot allocate free ip in ipam: %v", ee)
 		}
-		return "", "", fmt.Errorf("cannot allocate free ip in ipam")
+		return "", "", errors.New("cannot allocate free ip in ipam")
 	}
 
 	return ipAddress, parentPrefixCidr, nil

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -245,7 +246,7 @@ func (r networkResource) createNetwork(request *restful.Request, response *restf
 
 	if len(requestPayload.Prefixes) == 0 {
 		// TODO: Should return a bad request 401
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("no prefixes given")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("no prefixes given")) {
 			return
 		}
 	}
@@ -335,7 +336,7 @@ func (r networkResource) createNetwork(request *restful.Request, response *restf
 	}
 
 	if (privateSuper || underlay) && nat {
-		checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("private super or underlay network is not supposed to NAT"))
+		checkError(request, response, utils.CurrentFuncName(), errors.New("private super or underlay network is not supposed to NAT"))
 		return
 	}
 
@@ -421,12 +422,12 @@ func (r networkResource) allocateNetwork(request *restful.Request, response *res
 	}
 
 	if projectID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("projectid should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("projectid should not be empty")) {
 			return
 		}
 	}
 	if partitionID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("partitionid should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("partitionid should not be empty")) {
 			return
 		}
 	}
@@ -588,7 +589,7 @@ func (r networkResource) updateNetwork(request *restful.Request, response *restf
 	}
 
 	if oldNetwork.Shared && !newNetwork.Shared {
-		checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("once a network is marked as shared it is not possible to unshare it"))
+		checkError(request, response, utils.CurrentFuncName(), errors.New("once a network is marked as shared it is not possible to unshare it"))
 		return
 	}
 
@@ -667,7 +668,7 @@ func (r networkResource) deleteNetwork(request *restful.Request, response *restf
 	}
 
 	if len(children) != 0 {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("network cannot be deleted because there are children of this network")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("network cannot be deleted because there are children of this network")) {
 			return
 		}
 	}

--- a/cmd/metal-api/internal/service/partition-service.go
+++ b/cmd/metal-api/internal/service/partition-service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
@@ -9,8 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	v1 "github.com/metal-stack/metal-api/cmd/metal-api/internal/service/v1"
-
-	"fmt"
 
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	restful "github.com/emicklei/go-restful/v3"
@@ -155,7 +154,7 @@ func (r partitionResource) createPartition(request *restful.Request, response *r
 	}
 
 	if requestPayload.ID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("id should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("id should not be empty")) {
 			return
 		}
 	}
@@ -176,7 +175,7 @@ func (r partitionResource) createPartition(request *restful.Request, response *r
 	if requestPayload.PrivateNetworkPrefixLength != nil {
 		prefixLength = *requestPayload.PrivateNetworkPrefixLength
 		if prefixLength < 16 || prefixLength > 30 {
-			if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("private network prefix length is out of range")) {
+			if checkError(request, response, utils.CurrentFuncName(), errors.New("private network prefix length is out of range")) {
 				return
 			}
 		}

--- a/cmd/metal-api/internal/service/project-service.go
+++ b/cmd/metal-api/internal/service/project-service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/metal-stack/masterdata-api/api/rest/mapper"
@@ -181,7 +180,7 @@ func (r projectResource) createProject(request *restful.Request, response *restf
 	project := mapper.ToMdmV1Project(&pcr.Project)
 
 	if project.TenantId == "" {
-		checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("no tenant given"))
+		checkError(request, response, utils.CurrentFuncName(), errors.New("no tenant given"))
 		return
 	}
 
@@ -223,7 +222,7 @@ func (r projectResource) deleteProject(request *restful.Request, response *restf
 		return
 	}
 	if len(ms) > 0 {
-		checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("there are still machines allocated by this project"))
+		checkError(request, response, utils.CurrentFuncName(), errors.New("there are still machines allocated by this project"))
 		return
 	}
 
@@ -233,7 +232,7 @@ func (r projectResource) deleteProject(request *restful.Request, response *restf
 		return
 	}
 	if len(ns) > 0 {
-		checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("there are still networks allocated by this project"))
+		checkError(request, response, utils.CurrentFuncName(), errors.New("there are still networks allocated by this project"))
 		return
 	}
 
@@ -244,7 +243,7 @@ func (r projectResource) deleteProject(request *restful.Request, response *restf
 	}
 
 	if len(ips) > 0 {
-		checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("there are still ips allocated by this project"))
+		checkError(request, response, utils.CurrentFuncName(), errors.New("there are still ips allocated by this project"))
 		return
 	}
 
@@ -310,7 +309,7 @@ func (r projectResource) updateProject(request *restful.Request, response *restf
 
 func (r projectResource) setProjectQuota(project *mdmv1.Project) (*v1.Project, error) {
 	if project.Meta == nil {
-		return nil, fmt.Errorf("project does not have a projectID")
+		return nil, errors.New("project does not have a projectID")
 	}
 	projectID := project.Meta.Id
 

--- a/cmd/metal-api/internal/service/project-service_test.go
+++ b/cmd/metal-api/internal/service/project-service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -93,7 +94,7 @@ func Test_projectResource_findProject(t *testing.T) {
 			userScenarios: []security.User{*noUser},
 			id:            "121",
 			wantStatus:    403,
-			wantErr:       httperrors.Forbidden(fmt.Errorf("you are not member in one of [k8s_kaas-view maas-all-all-view k8s_kaas-edit maas-all-all-edit k8s_kaas-admin maas-all-all-admin]")),
+			wantErr:       httperrors.Forbidden(errors.New("you are not member in one of [k8s_kaas-view maas-all-all-view k8s_kaas-edit maas-all-all-edit k8s_kaas-admin maas-all-all-admin]")),
 		},
 		{
 			name:          "entity allowed for user with view privileges",
@@ -103,7 +104,7 @@ func Test_projectResource_findProject(t *testing.T) {
 				mock.On("Get", context.Background(), &mdmv1.ProjectGetRequest{Id: "122"}).Return(&mdmv1.ProjectResponse{Project: &mdmv1.Project{}}, nil)
 			},
 			wantStatus: 422,
-			wantErr:    httperrors.UnprocessableEntity(fmt.Errorf("project does not have a projectID")),
+			wantErr:    httperrors.UnprocessableEntity(errors.New("project does not have a projectID")),
 		},
 		{
 			name:          "entity allowed for user with admin privileges",
@@ -113,7 +114,7 @@ func Test_projectResource_findProject(t *testing.T) {
 			},
 			id:         "123",
 			wantStatus: 422,
-			wantErr:    httperrors.UnprocessableEntity(fmt.Errorf("project does not have a projectID")),
+			wantErr:    httperrors.UnprocessableEntity(errors.New("project does not have a projectID")),
 		},
 	}
 	for _, tt := range tests {
@@ -155,7 +156,7 @@ func Test_projectResource_createProject(t *testing.T) {
 			userScenarios: []security.User{*noUser},
 			pcr:           &mdmv1.ProjectCreateRequest{Project: &mdmv1.Project{}},
 			wantStatus:    403,
-			wantErr:       httperrors.Forbidden(fmt.Errorf("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
+			wantErr:       httperrors.Forbidden(errors.New("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
 		},
 		{
 			name:          "entity allowed for user with view privileges",
@@ -165,7 +166,7 @@ func Test_projectResource_createProject(t *testing.T) {
 				mock.On("Create", context.Background(), &mdmv1.ProjectCreateRequest{Project: &mdmv1.Project{}}).Return(&mdmv1.ProjectResponse{Project: &mdmv1.Project{}}, nil)
 			},
 			wantStatus: 403,
-			wantErr:    httperrors.Forbidden(fmt.Errorf("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
+			wantErr:    httperrors.Forbidden(errors.New("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
 		},
 		{
 			name:          "entity allowed for user with admin privileges",
@@ -175,7 +176,7 @@ func Test_projectResource_createProject(t *testing.T) {
 				mock.On("Create", context.Background(), &mdmv1.ProjectCreateRequest{Project: &mdmv1.Project{}}).Return(&mdmv1.ProjectResponse{Project: &mdmv1.Project{}}, nil)
 			},
 			wantStatus: 422,
-			wantErr:    httperrors.UnprocessableEntity(fmt.Errorf("no tenant given")),
+			wantErr:    httperrors.UnprocessableEntity(errors.New("no tenant given")),
 		},
 	}
 	for _, tt := range tests {
@@ -218,7 +219,7 @@ func Test_projectResource_deleteProject(t *testing.T) {
 			userScenarios: []security.User{*noUser},
 			id:            "121",
 			wantStatus:    403,
-			wantErr:       httperrors.Forbidden(fmt.Errorf("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
+			wantErr:       httperrors.Forbidden(errors.New("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
 		},
 		{
 			name:          "entity allowed for user with view privileges",
@@ -228,7 +229,7 @@ func Test_projectResource_deleteProject(t *testing.T) {
 				mock.On("Delete", context.Background(), &mdmv1.ProjectDeleteRequest{Id: "122"}).Return(&mdmv1.ProjectResponse{Project: &mdmv1.Project{}}, nil)
 			},
 			wantStatus: 403,
-			wantErr:    httperrors.Forbidden(fmt.Errorf("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
+			wantErr:    httperrors.Forbidden(errors.New("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
 		},
 		{
 			name:          "entity allowed for user with admin privileges",
@@ -287,7 +288,7 @@ func Test_projectResource_updateProject(t *testing.T) {
 			userScenarios: []security.User{*noUser},
 			pur:           &mdmv1.ProjectUpdateRequest{Project: &mdmv1.Project{}},
 			wantStatus:    403,
-			wantErr:       httperrors.Forbidden(fmt.Errorf("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
+			wantErr:       httperrors.Forbidden(errors.New("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
 		},
 		{
 			name:          "entity allowed for user with view privileges",
@@ -297,7 +298,7 @@ func Test_projectResource_updateProject(t *testing.T) {
 				mock.On("Update", context.Background(), &mdmv1.ProjectUpdateRequest{Project: &mdmv1.Project{}}).Return(&mdmv1.ProjectResponse{Project: &mdmv1.Project{}}, nil)
 			},
 			wantStatus: 403,
-			wantErr:    httperrors.Forbidden(fmt.Errorf("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
+			wantErr:    httperrors.Forbidden(errors.New("you are not member in one of [k8s_kaas-admin maas-all-all-admin]")),
 		},
 		{
 			name:          "entity allowed for user with admin privileges",
@@ -307,7 +308,7 @@ func Test_projectResource_updateProject(t *testing.T) {
 				mock.On("Update", context.Background(), &mdmv1.ProjectUpdateRequest{Project: &mdmv1.Project{}}).Return(&mdmv1.ProjectResponse{Project: &mdmv1.Project{}}, nil)
 			},
 			wantStatus: 422,
-			wantErr:    httperrors.UnprocessableEntity(fmt.Errorf("project and project.meta must be specified")),
+			wantErr:    httperrors.UnprocessableEntity(errors.New("project and project.meta must be specified")),
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/metal-api/internal/service/size-service.go
+++ b/cmd/metal-api/internal/service/size-service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -139,7 +140,7 @@ func (r sizeResource) createSize(request *restful.Request, response *restful.Res
 	}
 
 	if requestPayload.ID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("id should not be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("id should not be empty")) {
 			return
 		}
 	}
@@ -286,7 +287,7 @@ func (r sizeResource) fromHardware(request *restful.Request, response *restful.R
 	}
 
 	if len(lg) < 1 {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("size matching log is empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("size matching log is empty")) {
 			return
 		}
 	}

--- a/cmd/metal-api/internal/service/switch-service.go
+++ b/cmd/metal-api/internal/service/switch-service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -226,7 +227,7 @@ func (r switchResource) registerSwitch(request *restful.Request, response *restf
 	}
 
 	if requestPayload.ID == "" {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("uuid cannot be empty")) {
+		if checkError(request, response, utils.CurrentFuncName(), errors.New("uuid cannot be empty")) {
 			return
 		}
 	}
@@ -249,7 +250,7 @@ func (r switchResource) registerSwitch(request *restful.Request, response *restf
 		s = v1.NewSwitch(requestPayload)
 
 		if len(requestPayload.Nics) != len(s.Nics.ByMac()) {
-			if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("duplicate mac addresses found in nics")) {
+			if checkError(request, response, utils.CurrentFuncName(), errors.New("duplicate mac addresses found in nics")) {
 				return
 			}
 		}
@@ -271,7 +272,7 @@ func (r switchResource) registerSwitch(request *restful.Request, response *restf
 		old := *s
 		spec := v1.NewSwitch(requestPayload)
 		if len(requestPayload.Nics) != len(spec.Nics.ByMac()) {
-			if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("duplicate mac addresses found in nics")) {
+			if checkError(request, response, utils.CurrentFuncName(), errors.New("duplicate mac addresses found in nics")) {
 				return
 			}
 		}
@@ -366,7 +367,7 @@ func adoptFromTwin(old, twin, new *metal.Switch) (*metal.Switch, error) {
 		return nil, fmt.Errorf("old and new switch belong to different racks, old: %v, new: %v", old.RackID, new.RackID)
 	}
 	if twin.Mode == metal.SwitchReplace {
-		return nil, fmt.Errorf("twin switch must not be in replace mode")
+		return nil, errors.New("twin switch must not be in replace mode")
 	}
 	if len(twin.MachineConnections) == 0 {
 		// twin switch has no machine connections, switch may be used immediately, replace mode is unnecessary

--- a/cmd/metal-api/internal/testdata/testdata.go
+++ b/cmd/metal-api/internal/testdata/testdata.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/metal-stack/metal-lib/pkg/tag"
@@ -769,18 +769,18 @@ func InitMockDBData(mock *r.Mock) {
 	mock.On(r.DB("mockdb").Table("size").Get("1")).Return(Sz1, nil)
 	mock.On(r.DB("mockdb").Table("size").Get("2")).Return(Sz2, nil)
 	mock.On(r.DB("mockdb").Table("size").Get("3")).Return(Sz3, nil)
-	mock.On(r.DB("mockdb").Table("size").Get("404")).Return(nil, fmt.Errorf("Test Error"))
+	mock.On(r.DB("mockdb").Table("size").Get("404")).Return(nil, errors.New("Test Error"))
 	mock.On(r.DB("mockdb").Table("size").Get("999")).Return(nil, nil)
 	mock.On(r.DB("mockdb").Table("partition").Get("1")).Return(Partition1, nil)
 	mock.On(r.DB("mockdb").Table("partition").Get("2")).Return(Partition2, nil)
 	mock.On(r.DB("mockdb").Table("partition").Get("3")).Return(Partition3, nil)
-	mock.On(r.DB("mockdb").Table("partition").Get("404")).Return(nil, fmt.Errorf("Test Error"))
+	mock.On(r.DB("mockdb").Table("partition").Get("404")).Return(nil, errors.New("Test Error"))
 	mock.On(r.DB("mockdb").Table("partition").Get("999")).Return(nil, nil)
 	mock.On(r.DB("mockdb").Table("image").Get("image-1")).Return(Img1, nil)
 	mock.On(r.DB("mockdb").Table("image").Get("image-2")).Return(Img2, nil)
 	mock.On(r.DB("mockdb").Table("image").Get("image-3")).Return(Img3, nil)
 	mock.On(r.DB("mockdb").Table("image").Get("image-4")).Return(Img4, nil)
-	mock.On(r.DB("mockdb").Table("image").Get("404")).Return(nil, fmt.Errorf("Test Error"))
+	mock.On(r.DB("mockdb").Table("image").Get("404")).Return(nil, errors.New("Test Error"))
 	mock.On(r.DB("mockdb").Table("image").Get("image-999")).Return(nil, nil)
 	mock.On(r.DB("mockdb").Table("network").Get(Nw1.ID)).Return(Nw1, nil)
 	mock.On(r.DB("mockdb").Table("network").Get(Nw2.ID)).Return(Nw2, nil)
@@ -796,14 +796,14 @@ func InitMockDBData(mock *r.Mock) {
 	mock.On(r.DB("mockdb").Table("network").Get(Partition2PrivateSuperNetwork.ID)).Return(Partition2PrivateSuperNetwork, nil)
 	mock.On(r.DB("mockdb").Table("network").Get(Partition2UnderlayNetwork.ID)).Return(Partition2UnderlayNetwork, nil)
 
-	mock.On(r.DB("mockdb").Table("network").Get("404")).Return(nil, fmt.Errorf("Test Error"))
+	mock.On(r.DB("mockdb").Table("network").Get("404")).Return(nil, errors.New("Test Error"))
 	mock.On(r.DB("mockdb").Table("network").Get("999")).Return(nil, nil)
 	mock.On(r.DB("mockdb").Table("network").Filter(func(var_3 r.Term) r.Term { return var_3.Field("partitionid").Eq("1") }).Filter(func(var_4 r.Term) r.Term { return var_4.Field("privatesuper").Eq(true) })).Return(Nw3, nil)
 
 	mock.On(r.DB("mockdb").Table("ip").Get("1.2.3.4")).Return(IP1, nil)
 	mock.On(r.DB("mockdb").Table("ip").Get("2.3.4.5")).Return(IP2, nil)
 	mock.On(r.DB("mockdb").Table("ip").Get("3.4.5.6")).Return(IP3, nil)
-	mock.On(r.DB("mockdb").Table("ip").Get("8.8.8.8")).Return(nil, fmt.Errorf("Test Error"))
+	mock.On(r.DB("mockdb").Table("ip").Get("8.8.8.8")).Return(nil, errors.New("Test Error"))
 	mock.On(r.DB("mockdb").Table("ip").Get("9.9.9.9")).Return(nil, nil)
 	mock.On(r.DB("mockdb").Table("ip").Get(Partition1InternetIP.IPAddress)).Return(Partition1InternetIP, nil)
 	mock.On(r.DB("mockdb").Table("ip").Get(Partition2InternetIP.IPAddress)).Return(Partition2InternetIP, nil)
@@ -817,7 +817,7 @@ func InitMockDBData(mock *r.Mock) {
 	mock.On(r.DB("mockdb").Table("machine").Get("6")).Return(M6, nil)
 	mock.On(r.DB("mockdb").Table("machine").Get("7")).Return(M7, nil)
 	mock.On(r.DB("mockdb").Table("machine").Get("8")).Return(M8, nil)
-	mock.On(r.DB("mockdb").Table("machine").Get("404")).Return(nil, fmt.Errorf("Test Error"))
+	mock.On(r.DB("mockdb").Table("machine").Get("404")).Return(nil, errors.New("Test Error"))
 	mock.On(r.DB("mockdb").Table("machine").Get("999")).Return(nil, nil)
 	mock.On(r.DB("mockdb").Table("machine").Filter(func(var_1 r.Term) r.Term {
 		return var_1.Field("partitionid").Eq(Partition1.ID)
@@ -825,7 +825,7 @@ func InitMockDBData(mock *r.Mock) {
 	mock.On(r.DB("mockdb").Table("switch").Get("switch1")).Return(Switch1, nil)
 	mock.On(r.DB("mockdb").Table("switch").Get("switch2")).Return(Switch2, nil)
 	mock.On(r.DB("mockdb").Table("switch").Get("switch3")).Return(Switch3, nil)
-	mock.On(r.DB("mockdb").Table("switch").Get("switch404")).Return(nil, fmt.Errorf("Test Error"))
+	mock.On(r.DB("mockdb").Table("switch").Get("switch404")).Return(nil, errors.New("Test Error"))
 	mock.On(r.DB("mockdb").Table("switch").Get("switch999")).Return(nil, nil)
 	mock.On(r.DB("mockdb").Table("wait").Get("3").Changes()).Return([]interface{}{
 		map[string]interface{}{"new_val": M3},

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -407,7 +407,7 @@ func connectDataStore(opts ...dsConnectOpt) error {
 		case DataStoreConnectTableInit:
 			initTables = true
 		default:
-			return fmt.Errorf("unsupported datastore connect option")
+			return errors.New("unsupported datastore connect option")
 		}
 	}
 


### PR DESCRIPTION
…no formatting is needed; avoid variable names hiding keywords and package names