### PR TITLE
Dynamically calculate rack ID in machine registration

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -592,10 +592,7 @@ func (r machineResource) registerMachine(request *restful.Request, response *res
 			Allocation:  nil,
 			SizeID:      size.ID,
 			PartitionID: partition.ID,
-			// the RackID is calculated by the switch connections
-			// a metal-core instance might respond to pxe requests from all racks
-			//RackID:      requestPayload.RackID,
-			Hardware: machineHardware,
+			Hardware:    machineHardware,
 			BIOS: metal.BIOS{
 				Version: requestPayload.BIOS.Version,
 				Vendor:  requestPayload.BIOS.Vendor,
@@ -624,9 +621,6 @@ func (r machineResource) registerMachine(request *restful.Request, response *res
 
 		m.SizeID = size.ID
 		m.PartitionID = partition.ID
-		// the RackID is calculated by the switch connections
-		// a metal-core instance might respond to pxe requests from all racks
-		//m.RackID = requestPayload.RackID,
 		m.Hardware = machineHardware
 		m.BIOS.Version = requestPayload.BIOS.Version
 		m.BIOS.Vendor = requestPayload.BIOS.Vendor

--- a/cmd/metal-api/internal/service/switch-service.go
+++ b/cmd/metal-api/internal/service/switch-service.go
@@ -547,7 +547,7 @@ func setVrf(s *metal.Switch, mid, vrf string) {
 }
 
 func connectMachineWithSwitches(ds *datastore.RethinkStore, m *metal.Machine) error {
-	switches, err := ds.SearchSwitches(m.RackID, nil)
+	switches, err := ds.SearchSwitches("", nil)
 	if err != nil {
 		return err
 	}
@@ -573,6 +573,12 @@ func connectMachineWithSwitches(ds *datastore.RethinkStore, m *metal.Machine) er
 	if len(cons1) != len(cons2) {
 		return connectionMapError
 	}
+
+	if s1.RackID != s2.RackID {
+		return fmt.Errorf("connected switches of a machine must reside in the same rack, rack of switch %s: %s, rack of switch %s: %s, machine: %s", s1.Name, s1.RackID, s2.Name, s2.RackID, m.ID)
+	}
+	// We detect the rackID of a machine by connections to leaf switches
+	m.RackID = s1.RackID
 
 	byNicName, err := s2.MachineConnections.ByNicName()
 	if err != nil {

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -157,13 +157,14 @@ type MachineFru struct {
 }
 
 type MachineRegisterRequest struct {
-	UUID        string                  `json:"uuid" description:"the product uuid of the machine to register"`
-	PartitionID string                  `json:"partitionid" description:"the partition id to register this machine with"`
-	RackID      string                  `json:"rackid" description:"the rack id where this machine is connected to"`
-	Hardware    MachineHardwareExtended `json:"hardware" description:"the hardware of this machine"`
-	BIOS        MachineBIOS             `json:"bios" description:"bios information of this machine"`
-	IPMI        MachineIPMI             `json:"ipmi" description:"the ipmi access infos"`
-	Tags        []string                `json:"tags" description:"tags for this machine"`
+	UUID        string `json:"uuid" description:"the product uuid of the machine to register"`
+	PartitionID string `json:"partitionid" description:"the partition id to register this machine with"`
+	// Deprecated: RackID is not used any longer, it is calculated by the switch connections of a machine. A metal-core instance might respond to pxe requests from all racks
+	RackID   string                  `json:"rackid" description:"the rack id where this machine is connected to"`
+	Hardware MachineHardwareExtended `json:"hardware" description:"the hardware of this machine"`
+	BIOS     MachineBIOS             `json:"bios" description:"bios information of this machine"`
+	IPMI     MachineIPMI             `json:"ipmi" description:"the ipmi access infos"`
+	Tags     []string                `json:"tags" description:"tags for this machine"`
 }
 
 type MachineAllocateRequest struct {


### PR DESCRIPTION
Fixes a bug leading to machine registration failure when using multiple leaf pairs in the same partition.

Fixes #181 