### PR TITLE
Return unknownSize instead of nil if no matching size was found

### DIFF
--- a/cmd/metal-api/internal/datastore/migrations/03_add_unknown_size.go
+++ b/cmd/metal-api/internal/datastore/migrations/03_add_unknown_size.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
+
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
+)
+
+func init() {
+	datastore.MustRegisterMigration(datastore.Migration{
+		Name:    "generate a unknown size if not present",
+		Version: 3,
+		Up: func(db *r.Term, session r.QueryExecutor, rs *datastore.RethinkStore) error {
+			_, err := rs.FindSize("unknown")
+			if err != nil {
+				return err
+			}
+			err = rs.CreateSize(metal.UnknownSize)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	})
+}

--- a/cmd/metal-api/internal/datastore/migrations/03_add_unknown_size.go
+++ b/cmd/metal-api/internal/datastore/migrations/03_add_unknown_size.go
@@ -14,11 +14,10 @@ func init() {
 		Up: func(db *r.Term, session r.QueryExecutor, rs *datastore.RethinkStore) error {
 			_, err := rs.FindSize("unknown")
 			if err != nil {
-				return err
-			}
-			err = rs.CreateSize(metal.UnknownSize)
-			if err != nil {
-				return err
+				err = rs.CreateSize(metal.UnknownSize)
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/cmd/metal-api/internal/metal/size.go
+++ b/cmd/metal-api/internal/metal/size.go
@@ -95,10 +95,10 @@ nextsize:
 	}
 
 	if len(found) == 0 {
-		return nil, matchlog, NotFound("no size found for hardware (%s)", hardware.ReadableSpec())
+		return UnknownSize, matchlog, NotFound("no size found for hardware (%s)", hardware.ReadableSpec())
 	}
 	if len(found) > 1 {
-		return nil, matchlog, fmt.Errorf("%d sizes found for hardware (%s)", len(found), hardware.ReadableSpec())
+		return UnknownSize, matchlog, fmt.Errorf("%d sizes found for hardware (%s)", len(found), hardware.ReadableSpec())
 	}
 	return &found[0], []*SizeMatchingLog{matchedlog}, nil
 }

--- a/cmd/metal-api/internal/metal/size_test.go
+++ b/cmd/metal-api/internal/metal/size_test.go
@@ -189,7 +189,7 @@ func TestSizes_FromHardware(t *testing.T) {
 					Memory:   1024,
 				},
 			},
-			want:    nil,
+			want:    UnknownSize,
 			wantErr: true,
 		},
 		{
@@ -201,7 +201,7 @@ func TestSizes_FromHardware(t *testing.T) {
 					Memory:   2500,
 				},
 			},
-			want:    nil,
+			want:    UnknownSize,
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
This will require to create a size with ID: "unknown" in the database to make this work