### PR TITLE
execute integration in a seperate job to speed up ci

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -22,16 +22,11 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.32.2
         args: --build-tags integration -p bugs -p unused --timeout=3m
 
     - name: Build Docker image
       run: |
         docker build -t ghcr.io/metal-stack/metal-api .
-
-    - name: Run integration tests
-      run: |
-        go test -tags=integration -timeout 600s -p 1 ./...
 
     - name: Push Docker image
       run: |
@@ -40,3 +35,12 @@ jobs:
     - uses: release-drafter/release-drafter@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run integration tests
+      run: |
+        go test -tags=integration -timeout 600s -p 1 ./...

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,19 +27,23 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.32.2
         args: --build-tags integration -p bugs -p unused --timeout=3m
 
     - name: Build Docker image
       run: |
         docker build -t ghcr.io/metal-stack/metal-api:pr-${GITHUB_HEAD_REF##*/} .
 
-    - name: Run integration tests
-      run: |
-        go test -tags=integration -timeout 600s -p 1 ./...
-
     - name: Push Docker image
       run: |
         # pull request images are prefixed with 'pr' to prevent them from overriding released images
         docker push ghcr.io/metal-stack/metal-api:pr-${GITHUB_HEAD_REF##*/}
       if: steps.fork.outputs.is_fork_pr == 'false'
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run integration tests
+      run: |
+        go test -tags=integration -timeout 600s -p 1 ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.32.2
         args: --build-tags integration -p bugs -p unused --timeout=3m
 
     - name: Build and push Docker image


### PR DESCRIPTION
This reduces pipeline execution from ~7:00 to ~4:30 min