### PR TITLE
Don't swallow error message on `setVrfAtSwitches`.

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1632,7 +1632,7 @@ func (r machineResource) finalizeAllocation(request *restful.Request, response *
 
 	_, err = setVrfAtSwitches(r.ds, m, vrf)
 	if err != nil {
-		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("the machine %q could not be enslaved into the vrf %s", id, vrf)) {
+		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("the machine %q could not be enslaved into the vrf %s, error: %w", id, vrf, err)) {
 			return
 		}
 	}


### PR DESCRIPTION
References https://github.com/metal-stack/metal-api/issues/207.