### PR TITLE
Improve stability of finalize allocation function.

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1593,25 +1593,6 @@ func (r machineResource) finalizeAllocation(request *restful.Request, response *
 		}
 	}
 
-	old := *m
-
-	m.Allocation.ConsolePassword = requestPayload.ConsolePassword
-	m.Allocation.MachineSetup = &metal.MachineSetup{
-		ImageID:      m.Allocation.ImageID,
-		PrimaryDisk:  requestPayload.PrimaryDisk,
-		OSPartition:  requestPayload.OSPartition,
-		Initrd:       requestPayload.Initrd,
-		Cmdline:      requestPayload.Cmdline,
-		Kernel:       requestPayload.Kernel,
-		BootloaderID: requestPayload.BootloaderID,
-	}
-	m.Allocation.Reinstall = false
-
-	err = r.ds.UpdateMachine(&old, m)
-	if checkError(request, response, utils.CurrentFuncName(), err) {
-		return
-	}
-
 	vrf := ""
 	imgs, err := r.ds.ListImages()
 	if checkError(request, response, utils.CurrentFuncName(), err) {
@@ -1635,6 +1616,26 @@ func (r machineResource) finalizeAllocation(request *restful.Request, response *
 		if checkError(request, response, utils.CurrentFuncName(), fmt.Errorf("the machine %q could not be enslaved into the vrf %s", id, vrf)) {
 			return
 		}
+	}
+
+	old := *m
+
+	m.Allocation.ConsolePassword = requestPayload.ConsolePassword
+	m.Allocation.MachineSetup = &metal.MachineSetup{
+		ImageID:      m.Allocation.ImageID,
+		PrimaryDisk:  requestPayload.PrimaryDisk,
+		OSPartition:  requestPayload.OSPartition,
+		Initrd:       requestPayload.Initrd,
+		Cmdline:      requestPayload.Cmdline,
+		Kernel:       requestPayload.Kernel,
+		BootloaderID: requestPayload.BootloaderID,
+	}
+	m.Allocation.Reinstall = false
+	m.Allocation.Succeeded = true
+
+	err = r.ds.UpdateMachine(&old, m)
+	if checkError(request, response, utils.CurrentFuncName(), err) {
+		return
 	}
 
 	err = response.WriteHeaderAndEntity(http.StatusOK, makeMachineResponse(m, r.ds, utils.Logger(request).Sugar()))


### PR DESCRIPTION
- Runs `MachineUpdate` after the `SwitchUpdate`
  - `SwitchUpdate` has a higher chance to run into concurrent modification errors (#207) and we don't want to leave `reinstall` mode before the machine was put into right VRF
  - Also for regular installations we don't want to start the machine in the next loop when it's not in the right VRF
- `Allocation.Succeeded` gets set (#209) preventing metal-core to re-run the hammer after finalizing the allocation