### PR TITLE
Remove old errors pkg

### DIFF
--- a/cmd/metal-api/internal/metal/errors.go
+++ b/cmd/metal-api/internal/metal/errors.go
@@ -1,7 +1,8 @@
 package metal
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 )
 
 var (
@@ -13,30 +14,30 @@ var (
 
 // NotFound creates a new notfound error with a given error message.
 func NotFound(format string, args ...interface{}) error {
-	return errors.Wrapf(errNotFound, format, args...)
+	return fmt.Errorf("%w %s", errNotFound, fmt.Sprintf(format, args...))
 }
 
 // IsNotFound checks if an error is a notfound error.
 func IsNotFound(e error) bool {
-	return errors.Is(errors.Cause(e), errNotFound)
+	return errors.Is(e, errNotFound)
 }
 
 // Conflict creates a new conflict error with a given error message.
 func Conflict(format string, args ...interface{}) error {
-	return errors.Wrapf(errConflict, format, args...)
+	return fmt.Errorf("%w %s", errConflict, fmt.Sprintf(format, args...))
 }
 
 // IsConflict checks if an error is a conflict error.
 func IsConflict(e error) bool {
-	return errors.Is(errors.Cause(e), errConflict)
+	return errors.Is(e, errConflict)
 }
 
 // Internal creates a new Internal error with a given error message and the original error.
 func Internal(err error, format string, args ...interface{}) error {
-	return errors.Wrap(errInternal, errors.Wrapf(err, format, args...).Error())
+	return fmt.Errorf("%w %s", errInternal, fmt.Errorf("%w %s", err, fmt.Sprintf(format, args...)))
 }
 
 // IsInternal checks if an error is a Internal error.
 func IsInternal(e error) bool {
-	return errors.Is(errors.Cause(e), errInternal)
+	return errors.Is(e, errInternal)
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/metal-stack/v v1.0.3
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nsqio/go-nsq v1.0.8
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/smartystreets/assertions v1.2.0 // indirect
 	github.com/spf13/cobra v1.2.1


### PR DESCRIPTION
Next attempt to remove the old external errors pkg with the stdlib one.

Maybe we should add more tests which covers our error behavior expectations.

after checking the errors_test.go, all cases are covered.