### PR TITLE
refactor allocation spec creation

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1221,7 +1221,7 @@ func validateAllocationSpec(allocationSpec *machineAllocationSpec) error {
 func findMachineCandidate(ds *datastore.RethinkStore, allocationSpec *machineAllocationSpec) (*metal.Machine, error) {
 	var err error
 	var machine *metal.Machine
-	if allocationSpec.UUID == "" {
+	if allocationSpec.Machine == nil {
 		// requesting allocation of an arbitrary ready machine in partition with given size
 		machine, err = findWaitingMachine(ds, allocationSpec.PartitionID, allocationSpec.Size.ID)
 		if err != nil {

--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1230,9 +1230,6 @@ func findMachineCandidate(ds *datastore.RethinkStore, allocationSpec *machineAll
 	} else {
 		// requesting allocation of a specific, existing machine
 		machine = allocationSpec.Machine
-		if machine == nil {
-			return nil, fmt.Errorf("machine cannot be nil")
-		}
 		if machine.Allocation != nil {
 			return nil, errors.New("machine is already allocated")
 		}

--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -968,7 +968,10 @@ func createMachineAllocationSpec(ds *datastore.RethinkStore, requestPayload v1.M
 	if requestPayload.UserData != nil {
 		userdata = *requestPayload.UserData
 	}
-	if requestPayload.Networks != nil && len(requestPayload.Networks) <= 0 {
+	if requestPayload.Networks == nil {
+		return nil, errors.New("network ids cannot be nil")
+	}
+	if len(requestPayload.Networks) <= 0 {
 		return nil, errors.New("network ids cannot be empty")
 	}
 
@@ -988,9 +991,10 @@ func createMachineAllocationSpec(ds *datastore.RethinkStore, requestPayload v1.M
 
 	partitionID := requestPayload.PartitionID
 	sizeID := requestPayload.SizeID
+	var m *metal.Machine
 	// Allocation of a specific machine is requested, therefore size and partition are not given, fetch them
 	if uuid != "" {
-		m, err := ds.FindMachineByID(uuid)
+		m, err = ds.FindMachineByID(uuid)
 		if err != nil {
 			return nil, fmt.Errorf("uuid given but no machine found with uuid:%s err:%w", uuid, err)
 		}

--- a/cmd/metal-api/internal/service/machine-service_test.go
+++ b/cmd/metal-api/internal/service/machine-service_test.go
@@ -817,7 +817,7 @@ func Test_validateAllocationSpec(t *testing.T) {
 				Creator:     testEmail,
 				PartitionID: "42",
 				ProjectID:   "123",
-				SizeID:      "42",
+				Size:        &testdata.Sz1,
 				Role:        metal.RoleMachine,
 			},
 			isError: false,
@@ -837,7 +837,7 @@ func Test_validateAllocationSpec(t *testing.T) {
 		{
 			spec: machineAllocationSpec{
 				Creator:   testEmail,
-				SizeID:    "42",
+				Size:      &testdata.Sz1,
 				ProjectID: "123",
 				Role:      metal.RoleMachine,
 			},

--- a/cmd/metal-api/internal/service/v1/firewall.go
+++ b/cmd/metal-api/internal/service/v1/firewall.go
@@ -2,6 +2,9 @@ package v1
 
 type FirewallCreateRequest struct {
 	MachineAllocateRequest
+	// HA if set to true firewall is created in ha configuration
+	//
+	// Deprecated: will be removed in the next release
 	HA *bool `json:"ha" description:"if set to true, this firewall is set up in a High Available manner" optional:"true"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/aws/aws-sdk-go v1.42.9
+	github.com/aws/aws-sdk-go v1.42.12
 	github.com/dustin/go-humanize v1.0.0
 	github.com/emicklei/go-restful-openapi/v2 v2.6.1
-	github.com/emicklei/go-restful/v3 v3.7.1
+	github.com/emicklei/go-restful/v3 v3.7.2
 	github.com/go-logr/zapr v1.2.0
 	github.com/go-openapi/spec v0.20.4
 	github.com/go-stack/stack v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:o
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/aws/aws-sdk-go v1.42.9 h1:8ptAGgA+uC2TUbdvUeOVSfBocIZvGE2NKiLxkAcn1GA=
-github.com/aws/aws-sdk-go v1.42.9/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.42.12 h1:zVrAgi3/HuMPygZknc+f2KAHcn+Zuq767857hnHBMPA=
+github.com/aws/aws-sdk-go v1.42.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -306,8 +306,9 @@ github.com/emicklei/go-restful-openapi/v2 v2.6.1/go.mod h1:i74MGi/3IdPTeSmWV/Xk5
 github.com/emicklei/go-restful/v3 v3.0.0-rc2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.3.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.5.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/emicklei/go-restful/v3 v3.7.1 h1:R5iagkkTsfFpe1nce6Yniw3wmSx0Qw5YP469YzRFNEs=
 github.com/emicklei/go-restful/v3 v3.7.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.7.2 h1:p3ZRPcKOgHhpoZbjFy+euxWCOP2cQOeSqnKp78BaNDQ=
+github.com/emicklei/go-restful/v3 v3.7.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
With this PR the duplicated code to fill the internal struct allocationspec was refactored to be reusable for machine and firewall allocation. Also the FirewallCreateRequest.HA field was never used and deprecated here.

This PR is a preparation for #232 to make the review of this PR easier.