### PR TITLE
Only query machines in the same partition as the ipmireport

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -797,7 +797,9 @@ func (r machineResource) ipmiReport(request *restful.Request, response *restful.
 	}
 
 	var ms metal.Machines
-	err = r.ds.SearchMachines(&datastore.MachineSearchQuery{}, &ms)
+	err = r.ds.SearchMachines(&datastore.MachineSearchQuery{
+		PartitionID: &p.ID,
+	}, &ms)
 	if checkError(request, response, utils.CurrentFuncName(), err) {
 		return
 	}


### PR DESCRIPTION
Currently all machines are queried, but the ipmireport is always partition scoped.