### PR TITLE
IP free and child network free should be DELETE methods.

### DIFF
--- a/cmd/metal-api/internal/datastore/ip.go
+++ b/cmd/metal-api/internal/datastore/ip.go
@@ -12,6 +12,7 @@ import (
 // IPSearchQuery can be used to search networks.
 type IPSearchQuery struct {
 	IPAddress        *string  `json:"ipaddress" modelDescription:"an ip address that can be attached to a machine" description:"the address (ipv4 or ipv6) of this ip" optional:"true"`
+	AllocationUUID   *string  `json:"allocationuuid" description:"a unique identifier for this ip address allocation, can be used to distinguish between ip address allocation over time." optional:"true"`
 	Name             *string  `json:"name" description:"the name of the ip address" optional:"true"`
 	ParentPrefixCidr *string  `json:"networkprefix" description:"the prefix of the network this ip address belongs to" optional:"true"`
 	NetworkID        *string  `json:"networkid" description:"the network this ip allocate request address belongs to" optional:"true"`
@@ -28,6 +29,12 @@ func (p *IPSearchQuery) generateTerm(rs *RethinkStore) *r.Term {
 	if p.IPAddress != nil {
 		q = q.Filter(func(row r.Term) r.Term {
 			return row.Field("id").Eq(*p.IPAddress)
+		})
+	}
+
+	if p.AllocationUUID != nil {
+		q = q.Filter(func(row r.Term) r.Term {
+			return row.Field("allocationuuid").Eq(*p.AllocationUUID)
 		})
 	}
 

--- a/cmd/metal-api/internal/service/ip-service.go
+++ b/cmd/metal-api/internal/service/ip-service.go
@@ -94,6 +94,7 @@ func (ir ipResource) webService() *restful.WebService {
 		Operation("freeIPDeprecated").
 		Doc("frees an ip").
 		Param(ws.PathParameter("id", "identifier of the ip").DataType("string")).
+		Consumes(restful.MIME_JSON, "*/*").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Writes(v1.IPResponse{}).
 		Returns(http.StatusOK, "OK", v1.IPResponse{}).

--- a/cmd/metal-api/internal/service/ip-service.go
+++ b/cmd/metal-api/internal/service/ip-service.go
@@ -91,6 +91,17 @@ func (ir ipResource) webService() *restful.WebService {
 
 	ws.Route(ws.POST("/free/{id}").
 		To(editor(ir.freeIP)).
+		Operation("freeIPDeprecated").
+		Doc("frees an ip").
+		Param(ws.PathParameter("id", "identifier of the ip").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(v1.IPResponse{}).
+		Returns(http.StatusOK, "OK", v1.IPResponse{}).
+		DefaultReturns("Error", httperrors.HTTPErrorResponse{}).
+		Deprecate())
+
+	ws.Route(ws.DELETE("/free/{id}").
+		To(editor(ir.freeIP)).
 		Operation("freeIP").
 		Doc("frees an ip").
 		Param(ws.PathParameter("id", "identifier of the ip").DataType("string")).

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -131,6 +131,7 @@ func (r networkResource) webService() *restful.WebService {
 		Operation("freeNetworkDeprecated").
 		Doc("free a network").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Consumes(restful.MIME_JSON, "*/*").
 		Param(ws.PathParameter("id", "identifier of the network").DataType("string")).
 		Returns(http.StatusOK, "OK", v1.NetworkResponse{}).
 		Returns(http.StatusConflict, "Conflict", httperrors.HTTPErrorResponse{}).

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -128,6 +128,17 @@ func (r networkResource) webService() *restful.WebService {
 
 	ws.Route(ws.POST("/free/{id}").
 		To(editor(r.freeNetwork)).
+		Operation("freeNetworkDeprecated").
+		Doc("free a network").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("id", "identifier of the network").DataType("string")).
+		Returns(http.StatusOK, "OK", v1.NetworkResponse{}).
+		Returns(http.StatusConflict, "Conflict", httperrors.HTTPErrorResponse{}).
+		DefaultReturns("Error", httperrors.HTTPErrorResponse{}).
+		Deprecate())
+
+	ws.Route(ws.DELETE("/free/{id}").
+		To(editor(r.freeNetwork)).
 		Operation("freeNetwork").
 		Doc("free a network").
 		Metadata(restfulspec.KeyOpenAPITags, tags).

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -4,6 +4,10 @@
     "datastore.IPSearchQuery": {
       "description": "an ip address that can be attached to a machine",
       "properties": {
+        "allocationuuid": {
+          "description": "a unique identifier for this ip address allocation, can be used to distinguish between ip address allocation over time.",
+          "type": "string"
+        },
         "ipaddress": {
           "description": "the address (ipv4 or ipv6) of this ip",
           "type": "string"
@@ -1318,6 +1322,10 @@
     },
     "v1.IPFindRequest": {
       "properties": {
+        "allocationuuid": {
+          "description": "a unique identifier for this ip address allocation, can be used to distinguish between ip address allocation over time.",
+          "type": "string"
+        },
         "ipaddress": {
           "description": "the address (ipv4 or ipv6) of this ip",
           "type": "string"

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -5617,6 +5617,7 @@
       },
       "post": {
         "consumes": [
+          "*/*",
           "application/json"
         ],
         "deprecated": true,
@@ -7159,6 +7160,7 @@
       },
       "post": {
         "consumes": [
+          "*/*",
           "application/json"
         ],
         "deprecated": true,

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -5579,11 +5579,48 @@
       }
     },
     "/v1/ip/free/{id}": {
-      "post": {
+      "delete": {
         "consumes": [
           "application/json"
         ],
         "operationId": "freeIP",
+        "parameters": [
+          {
+            "description": "identifier of the ip",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/v1.IPResponse"
+            }
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/definitions/httperrors.HTTPErrorResponse"
+            }
+          }
+        },
+        "summary": "frees an ip",
+        "tags": [
+          "ip"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "deprecated": true,
+        "operationId": "freeIPDeprecated",
         "parameters": [
           {
             "description": "identifier of the ip",
@@ -7078,11 +7115,54 @@
       }
     },
     "/v1/network/free/{id}": {
-      "post": {
+      "delete": {
         "consumes": [
           "application/json"
         ],
         "operationId": "freeNetwork",
+        "parameters": [
+          {
+            "description": "identifier of the network",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/v1.NetworkResponse"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/httperrors.HTTPErrorResponse"
+            }
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/definitions/httperrors.HTTPErrorResponse"
+            }
+          }
+        },
+        "summary": "free a network",
+        "tags": [
+          "network"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "deprecated": true,
+        "operationId": "freeNetworkDeprecated",
         "parameters": [
           {
             "description": "identifier of the network",


### PR DESCRIPTION
This fixes and actual bug with newer versions of go-openapi, which leaves out the accept header on empty payload: https://github.com/go-openapi/runtime/issues/231.

We could also make the existing endpoints consume an empty body or `*/*`, but I think this is more consistent to the rest of the API.