### PR TITLE
Ensure image and kernel in Partition are downloadable

### DIFF
--- a/cmd/metal-api/internal/service/integration_test.go
+++ b/cmd/metal-api/internal/service/integration_test.go
@@ -188,6 +188,7 @@ func createTestEnvironment(t *testing.T) testEnv {
 
 	partitionName := "test-partition"
 	partitionDesc := "Test Partition"
+	downloadableFile := "https://upload.wikimedia.org/wikipedia/commons/e/e6/1kb.png"
 	partition := v1.PartitionCreateRequest{
 		Common: v1.Common{
 			Identifiable: v1.Identifiable{
@@ -197,6 +198,10 @@ func createTestEnvironment(t *testing.T) testEnv {
 				Name:        &partitionName,
 				Description: &partitionDesc,
 			},
+		},
+		PartitionBootConfiguration: v1.PartitionBootConfiguration{
+			ImageURL:  &downloadableFile,
+			KernelURL: &downloadableFile,
 		},
 	}
 	var createdPartition v1.PartitionResponse

--- a/cmd/metal-api/internal/service/integration_test.go
+++ b/cmd/metal-api/internal/service/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -188,7 +189,13 @@ func createTestEnvironment(t *testing.T) testEnv {
 
 	partitionName := "test-partition"
 	partitionDesc := "Test Partition"
-	downloadableFile := "https://upload.wikimedia.org/wikipedia/commons/e/e6/1kb.png"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "I am a downloadable content")
+	}))
+	defer ts.Close()
+
+	downloadableFile := ts.URL
 	partition := v1.PartitionCreateRequest{
 		Common: v1.Common{
 			Identifiable: v1.Identifiable{

--- a/cmd/metal-api/internal/service/partition-service.go
+++ b/cmd/metal-api/internal/service/partition-service.go
@@ -190,9 +190,17 @@ func (r partitionResource) createPartition(request *restful.Request, response *r
 	if requestPayload.PartitionBootConfiguration.ImageURL != nil {
 		imageURL = *requestPayload.PartitionBootConfiguration.ImageURL
 	}
+	err = checkImageURL("image", imageURL)
+	if checkError(request, response, utils.CurrentFuncName(), err) {
+		return
+	}
 	var kernelURL string
 	if requestPayload.PartitionBootConfiguration.KernelURL != nil {
 		kernelURL = *requestPayload.PartitionBootConfiguration.KernelURL
+	}
+	err = checkImageURL("kernel", kernelURL)
+	if checkError(request, response, utils.CurrentFuncName(), err) {
+		return
 	}
 	var commandLine string
 	if requestPayload.PartitionBootConfiguration.CommandLine != nil {
@@ -276,9 +284,18 @@ func (r partitionResource) updatePartition(request *restful.Request, response *r
 		newPartition.MgmtServiceAddress = *requestPayload.MgmtServiceAddress
 	}
 	if requestPayload.PartitionBootConfiguration.ImageURL != nil {
+		err = checkImageURL("kernel", *requestPayload.PartitionBootConfiguration.ImageURL)
+		if checkError(request, response, utils.CurrentFuncName(), err) {
+			return
+		}
 		newPartition.BootConfiguration.ImageURL = *requestPayload.PartitionBootConfiguration.ImageURL
 	}
+
 	if requestPayload.PartitionBootConfiguration.KernelURL != nil {
+		err = checkImageURL("kernel", *requestPayload.PartitionBootConfiguration.KernelURL)
+		if checkError(request, response, utils.CurrentFuncName(), err) {
+			return
+		}
 		newPartition.BootConfiguration.KernelURL = *requestPayload.PartitionBootConfiguration.KernelURL
 	}
 	if requestPayload.PartitionBootConfiguration.CommandLine != nil {

--- a/cmd/metal-api/internal/service/partition-service_test.go
+++ b/cmd/metal-api/internal/service/partition-service_test.go
@@ -141,6 +141,7 @@ func TestCreatePartition(t *testing.T) {
 	}
 	service := NewPartition(ds, topicCreater)
 	container := restful.NewContainer().Add(service)
+	downloadableFile := "https://upload.wikimedia.org/wikipedia/commons/e/e6/1kb.png"
 
 	createRequest := v1.PartitionCreateRequest{
 		Common: v1.Common{
@@ -151,6 +152,10 @@ func TestCreatePartition(t *testing.T) {
 				Name:        &testdata.Partition1.Name,
 				Description: &testdata.Partition1.Description,
 			},
+		},
+		PartitionBootConfiguration: v1.PartitionBootConfiguration{
+			ImageURL:  &downloadableFile,
+			KernelURL: &downloadableFile,
 		},
 	}
 	js, err := json.Marshal(createRequest)
@@ -182,7 +187,7 @@ func TestUpdatePartition(t *testing.T) {
 	container := restful.NewContainer().Add(service)
 
 	mgmtService := "mgmt"
-	imageURL := "http://somewhere/image1.zip"
+	downloadableFile := "https://upload.wikimedia.org/wikipedia/commons/e/e6/1kb.png"
 	updateRequest := v1.PartitionUpdateRequest{
 		Common: v1.Common{
 			Describable: v1.Describable{
@@ -195,7 +200,7 @@ func TestUpdatePartition(t *testing.T) {
 		},
 		MgmtServiceAddress: &mgmtService,
 		PartitionBootConfiguration: &v1.PartitionBootConfiguration{
-			ImageURL: &imageURL,
+			ImageURL: &downloadableFile,
 		},
 	}
 	js, err := json.Marshal(updateRequest)
@@ -218,7 +223,7 @@ func TestUpdatePartition(t *testing.T) {
 	require.Equal(t, testdata.Partition2.Name, *result.Name)
 	require.Equal(t, testdata.Partition2.Description, *result.Description)
 	require.Equal(t, mgmtService, *result.MgmtServiceAddress)
-	require.Equal(t, imageURL, *result.PartitionBootConfiguration.ImageURL)
+	require.Equal(t, downloadableFile, *result.PartitionBootConfiguration.ImageURL)
 }
 
 func TestPartitionCapacity(t *testing.T) {

--- a/cmd/metal-api/internal/service/partition-service_test.go
+++ b/cmd/metal-api/internal/service/partition-service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -141,7 +142,13 @@ func TestCreatePartition(t *testing.T) {
 	}
 	service := NewPartition(ds, topicCreater)
 	container := restful.NewContainer().Add(service)
-	downloadableFile := "https://upload.wikimedia.org/wikipedia/commons/e/e6/1kb.png"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "I am a downloadable content")
+	}))
+	defer ts.Close()
+
+	downloadableFile := ts.URL
 
 	createRequest := v1.PartitionCreateRequest{
 		Common: v1.Common{
@@ -185,9 +192,13 @@ func TestUpdatePartition(t *testing.T) {
 
 	service := NewPartition(ds, &nopTopicCreater{})
 	container := restful.NewContainer().Add(service)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "I am a downloadable content")
+	}))
+	defer ts.Close()
 
 	mgmtService := "mgmt"
-	downloadableFile := "https://upload.wikimedia.org/wikipedia/commons/e/e6/1kb.png"
+	downloadableFile := ts.URL
 	updateRequest := v1.PartitionUpdateRequest{
 		Common: v1.Common{
 			Describable: v1.Describable{


### PR DESCRIPTION
Found during testing that we dont check if kernel or metal-hammer image are downloadable as we do for machine images.