### PR TITLE
Nested neighbors should not be nil in machine response.

### DIFF
--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -383,7 +383,7 @@ func NewMachineResponse(m *metal.Machine, s *metal.Size, p *metal.Partition, i *
 		neighs := MachineNics{}
 		for j := range n.Neighbors {
 			neigh := n.Neighbors[j]
-			neighs = append(neighs, MachineNic{MacAddress: string(neigh.MacAddress), Name: neigh.Name})
+			neighs = append(neighs, MachineNic{MacAddress: string(neigh.MacAddress), Name: neigh.Name, Neighbors: MachineNics{}})
 		}
 		nic := MachineNic{
 			MacAddress: string(n.MacAddress),


### PR DESCRIPTION
Otherwise breaks metal-python client.

```
...
   {
    "mac": "b4:96:91:49:95:d3",
    "name": "eth3",
    "neighbors": []
   },
   {
    "mac": "ac:1f:6b:7b:ed:30",
    "name": "eth4",
    "neighbors": [
     {
      "mac": "b8:6a:97:74:00:49",
      "name": "",
      "neighbors": null
     }
    ]
   },
...
```