### PR TITLE
If waiting machines are gone, ContextCancelledError is thrown, do not…

### DIFF
--- a/cmd/metal-api/internal/grpc/boot-service-wait.go
+++ b/cmd/metal-api/internal/grpc/boot-service-wait.go
@@ -34,9 +34,6 @@ func (b *BootService) Wait(req *v1.BootServiceWaitRequest, srv v1.BootService_Wa
 		return err
 	}
 	defer func() {
-		if err != nil {
-			return
-		}
 		err := b.updateWaitingFlag(machineID, false)
 		if err != nil {
 			b.log.Errorw("unable to remove waiting flag from machine", "machineID", machineID, "error", err)


### PR DESCRIPTION
… ignore that