### PR TITLE
RFC add option to skip transitives in findMachines

### DIFF
--- a/cmd/metal-api/internal/service/partition-service.go
+++ b/cmd/metal-api/internal/service/partition-service.go
@@ -375,7 +375,7 @@ func (r *partitionResource) calcPartitionCapacity(pcr *v1.PartitionCapacityReque
 	if err != nil {
 		return nil, err
 	}
-	machines, err := makeMachineResponseList(ms, r.ds)
+	machines, err := makeMachineResponseList(ms, r.ds, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -205,6 +205,7 @@ type MachineAllocationNetwork struct {
 
 type MachineFindRequest struct {
 	datastore.MachineSearchQuery
+	WithoutTransitives bool
 }
 
 // MachineUpdateRequest defines the properties of a machine which can be updated.

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -1096,6 +1096,9 @@
     },
     "v1.FirewallFindRequest": {
       "properties": {
+        "WithoutTransitives": {
+          "type": "boolean"
+        },
         "allocation_hostname": {
           "type": "string"
         },
@@ -1274,7 +1277,10 @@
           },
           "type": "array"
         }
-      }
+      },
+      "required": [
+        "WithoutTransitives"
+      ]
     },
     "v1.FirewallResponse": {
       "properties": {
@@ -2232,6 +2238,9 @@
     },
     "v1.MachineFindRequest": {
       "properties": {
+        "WithoutTransitives": {
+          "type": "boolean"
+        },
         "allocation_hostname": {
           "type": "string"
         },
@@ -2410,7 +2419,10 @@
           },
           "type": "array"
         }
-      }
+      },
+      "required": [
+        "WithoutTransitives"
+      ]
     },
     "v1.MachineFru": {
       "description": "The Field Replaceable Unit data",


### PR DESCRIPTION
This would potentially speed up the findMachines call which is actually by far the most demanding and slow api call.

This call is currently done from:

# MCM Metal
https://github.com/metal-stack/machine-controller-manager-provider-metal/blob/master/pkg/provider/core.go#L297

This i called every 30sec per cluster

Where it uses the partition transitive to get partitionID like so:
```go
providerID := encodeMachineID(*m.Partition.ID, *m.ID)
```
This should be changed to a direct partition field as string from the Machine object 

# Metal CCM
https://github.com/metal-stack/metal-ccm/blob/master/pkg/resources/metal/machine.go#L43
This is called at least every minute for every worker

Uses also Partition.ID as shown above

and:
```go
hostname := *m.Allocation.Hostname
machineTags[hostname] = m.Tags
```

Maybe we should change PartitionID to be contained directly in the machine Object and remove Partition Object altogether from this response object. Or simply copy over only machine.PartitionID to machineResponse.Partition.ID to keep backward compatibility
Another option would be to Create a new Endpoint which returns smaller Objects


# Analysing where to most time is spent in the metal-api

could be done with the pprof endpoint like so: https://www.benburwell.com/posts/flame-graphs-for-go-with-pprof/
