### PR TITLE
Add metal-core version to switch OS details

### DIFF
--- a/cmd/metal-api/internal/metal/switch.go
+++ b/cmd/metal-api/internal/metal/switch.go
@@ -26,8 +26,9 @@ type Switch struct {
 type Switches []Switch
 
 type SwitchOS struct {
-	Vendor  string `rethinkdb:"vendor" json:"vendor"`
-	Version string `rethinkdb:"version" json:"version"`
+	Vendor           string `rethinkdb:"vendor" json:"vendor"`
+	Version          string `rethinkdb:"version" json:"version"`
+	MetalCoreVersion string `rethinkdb:"metal_core_version" json:"metal_core_version"`
 }
 
 // Connection between switch port and machine.

--- a/cmd/metal-api/internal/service/switch-service.go
+++ b/cmd/metal-api/internal/service/switch-service.go
@@ -373,6 +373,7 @@ func (r *switchResource) registerSwitch(request *restful.Request, response *rest
 			}
 			s.OS.Vendor = spec.OS.Vendor
 			s.OS.Version = spec.OS.Version
+			s.OS.MetalCoreVersion = spec.OS.MetalCoreVersion
 		}
 		s.ManagementIP = spec.ManagementIP
 		s.ManagementUser = spec.ManagementUser

--- a/cmd/metal-api/internal/service/v1/switch.go
+++ b/cmd/metal-api/internal/service/v1/switch.go
@@ -18,8 +18,9 @@ type SwitchBase struct {
 }
 
 type SwitchOS struct {
-	Vendor  string `json:"vendor" description:"the operating system vendor the switch currently has" optional:"true"`
-	Version string `json:"version" description:"the operating system version the switch currently has" optional:"true"`
+	Vendor           string `json:"vendor" description:"the operating system vendor the switch currently has" optional:"true"`
+	Version          string `json:"version" description:"the operating system version the switch currently has" optional:"true"`
+	MetalCoreVersion string `json:"metal_core_version" description:"the version of metal-core running" optional:"true"`
 }
 
 type SwitchNics []SwitchNic

--- a/cmd/metal-api/internal/service/v1/switch.go
+++ b/cmd/metal-api/internal/service/v1/switch.go
@@ -116,8 +116,9 @@ func NewSwitchResponse(s *metal.Switch, p *metal.Partition, nics SwitchNics, con
 	var os *SwitchOS
 	if s.OS != nil {
 		os = &SwitchOS{
-			Vendor:  s.OS.Vendor,
-			Version: s.OS.Version,
+			Vendor:           s.OS.Vendor,
+			Version:          s.OS.Version,
+			MetalCoreVersion: s.OS.MetalCoreVersion,
 		}
 	}
 
@@ -175,8 +176,9 @@ func NewSwitch(r SwitchRegisterRequest) *metal.Switch {
 	var os *metal.SwitchOS
 	if r.OS != nil {
 		os = &metal.SwitchOS{
-			Vendor:  r.OS.Vendor,
-			Version: r.OS.Version,
+			Vendor:           r.OS.Vendor,
+			Version:          r.OS.Version,
+			MetalCoreVersion: r.OS.MetalCoreVersion,
 		}
 	}
 

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -4360,6 +4360,10 @@
     },
     "v1.SwitchOS": {
       "properties": {
+        "metal_core_version": {
+          "description": "the version of metal-core running",
+          "type": "string"
+        },
         "vendor": {
           "description": "the operating system vendor the switch currently has",
           "type": "string"


### PR DESCRIPTION
This enables us to show the metal-core version in `metalctl switch ls -o wide` as well

Related:

- [ ] https://github.com/metal-stack/metal-core/pull/98
- [ ] https://github.com/metal-stack/metalctl/pull/199