### PR TITLE
Resilient network free.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
-        args: --build-tags integration -p bugs -p unused --timeout=5m
+        args: --build-tags integration -p bugs -p unused -D protogetter --timeout=5m
 
     - name: Make tag
       run: |
@@ -53,7 +53,7 @@ jobs:
         make release
 
     - name: Push image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: true

--- a/cmd/metal-api/internal/ipam/ipam.go
+++ b/cmd/metal-api/internal/ipam/ipam.go
@@ -132,7 +132,7 @@ func (i *Ipam) ReleaseIP(ip metal.IP) error {
 func (i *Ipam) PrefixUsage(cidr string) (*metal.NetworkUsage, error) {
 	prefix := i.ip.PrefixFrom(cidr)
 	if prefix == nil {
-		return nil, metal.NotFound("prefix for cidr:%s not found", cidr)
+		return nil, fmt.Errorf("prefix for cidr:%s not found", cidr)
 	}
 	usage := prefix.Usage()
 

--- a/cmd/metal-api/internal/ipam/ipam.go
+++ b/cmd/metal-api/internal/ipam/ipam.go
@@ -50,6 +50,9 @@ func (i *Ipam) ReleaseChildPrefix(childPrefix metal.Prefix) error {
 
 	ipamChildPrefix := i.ip.PrefixFrom(childPrefix.String())
 	if ipamChildPrefix == nil {
+		// FIXME: unfortunately, go-ipam does not return a proper error here so we cannot deduce if the prefix
+		// was already deleted or not, so if the database is down or something we continue with network deletion
+		// even though there could be remainings in the go-ipam db
 		return nil
 	}
 

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -553,6 +553,10 @@ func (r *networkResource) freeNetwork(request *restful.Request, response *restfu
 	for _, prefix := range nw.Prefixes {
 		usage, err := r.ipamer.PrefixUsage(prefix.String())
 		if err != nil {
+			if metal.IsNotFound(err) {
+				continue
+			}
+
 			r.sendError(request, response, defaultError(err))
 			return
 		}
@@ -767,6 +771,7 @@ func getNetworkUsage(nw *metal.Network, ipamer ipam.IPAMer) *metal.NetworkUsage 
 	for _, prefix := range nw.Prefixes {
 		u, err := ipamer.PrefixUsage(prefix.String())
 		if err != nil {
+			// FIXME: the error should not be swallowed here as this can return wrong usage information to the clients
 			continue
 		}
 		usage.AvailableIPs = usage.AvailableIPs + u.AvailableIPs

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -551,25 +551,6 @@ func (r *networkResource) freeNetwork(request *restful.Request, response *restfu
 	}
 
 	for _, prefix := range nw.Prefixes {
-		usage, err := r.ipamer.PrefixUsage(prefix.String())
-		if err != nil {
-			if metal.IsNotFound(err) {
-				continue
-			}
-
-			r.sendError(request, response, defaultError(err))
-			return
-		}
-
-		if usage.UsedIPs > 2 {
-			if err != nil {
-				r.sendError(request, response, defaultError(fmt.Errorf("cannot release child prefix %s because IPs in the prefix are still in use: %v", prefix.String(), usage.UsedIPs-2)))
-				return
-			}
-		}
-	}
-
-	for _, prefix := range nw.Prefixes {
 		err = r.ipamer.ReleaseChildPrefix(prefix)
 		if err != nil {
 			r.sendError(request, response, defaultError(err))


### PR DESCRIPTION
It is possible for the API to end up in the state that the network entity in the RethinkDB contains network prefixes which were already freed partially. In this case, it is not possible to clean up the network anymore.