### PR TITLE
Introduce size reservations for projects.

### DIFF
--- a/cmd/metal-api/internal/metal/machine.go
+++ b/cmd/metal-api/internal/metal/machine.go
@@ -171,6 +171,22 @@ func (ms Machines) ByProjectID() map[string]Machines {
 	return res
 }
 
+func (ms Machines) WithSize(id string) Machines {
+	var res Machines
+
+	for _, m := range ms {
+		m := m
+
+		if m.SizeID != id {
+			continue
+		}
+
+		res = append(res, m)
+	}
+
+	return res
+}
+
 // MachineNetwork stores the Network details of the machine
 type MachineNetwork struct {
 	NetworkID           string   `rethinkdb:"networkid" json:"networkid"`

--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1317,7 +1317,7 @@ func findWaitingMachine(ds *datastore.RethinkStore, allocationSpec *machineAlloc
 		return nil, fmt.Errorf("partition cannot be found: %w", err)
 	}
 
-	machine, err := ds.FindWaitingMachine(allocationSpec.ProjectID, partition.ID, size.ID, allocationSpec.PlacementTags)
+	machine, err := ds.FindWaitingMachine(allocationSpec.ProjectID, partition.ID, *size, allocationSpec.PlacementTags)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/metal-api/internal/service/size-service.go
+++ b/cmd/metal-api/internal/service/size-service.go
@@ -213,6 +213,15 @@ func (r *sizeResource) createSize(request *restful.Request, response *restful.Re
 		}
 		constraints = append(constraints, constraint)
 	}
+	var reservations metal.Reservations
+	for _, r := range requestPayload.SizeReservations {
+		reservations = append(reservations, metal.Reservation{
+			Amount:       r.Amount,
+			Description:  r.Description,
+			ProjectID:    r.ProjectID,
+			PartitionIDs: r.PartitionIDs,
+		})
+	}
 
 	s := &metal.Size{
 		Base: metal.Base{
@@ -220,7 +229,8 @@ func (r *sizeResource) createSize(request *restful.Request, response *restful.Re
 			Name:        name,
 			Description: description,
 		},
-		Constraints: constraints,
+		Constraints:  constraints,
+		Reservations: reservations,
 	}
 
 	ss, err := r.ds.ListSizes()
@@ -301,6 +311,18 @@ func (r *sizeResource) updateSize(request *restful.Request, response *restful.Re
 			constraints = append(constraints, constraint)
 		}
 		newSize.Constraints = constraints
+	}
+	var reservations metal.Reservations
+	if requestPayload.SizeReservations != nil {
+		for _, r := range requestPayload.SizeReservations {
+			reservations = append(reservations, metal.Reservation{
+				Amount:       r.Amount,
+				Description:  r.Description,
+				ProjectID:    r.ProjectID,
+				PartitionIDs: r.PartitionIDs,
+			})
+		}
+		newSize.Reservations = reservations
 	}
 
 	ss, err := r.ds.ListSizes()

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -4340,6 +4340,13 @@
         "name": {
           "description": "a readable name for this entity",
           "type": "string"
+        },
+        "reservations": {
+          "description": "reservations for this size, which are considered during machine allocation",
+          "items": {
+            "$ref": "#/definitions/v1.SizeReservation"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -4473,6 +4480,35 @@
         "name"
       ]
     },
+    "v1.SizeReservation": {
+      "properties": {
+        "amount": {
+          "description": "the amount of reserved machine allocations for this size",
+          "format": "int32",
+          "type": "integer"
+        },
+        "description": {
+          "description": "a description for this reservation",
+          "type": "string"
+        },
+        "partitionids": {
+          "description": "the partitions in which this size reservation is considered, the amount is valid for every partition",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "projectid": {
+          "description": "the project for which this size reservation is considered",
+          "type": "string"
+        }
+      },
+      "required": [
+        "amount",
+        "partitionids",
+        "projectid"
+      ]
+    },
     "v1.SizeResponse": {
       "properties": {
         "changed": {
@@ -4506,6 +4542,13 @@
         "name": {
           "description": "a readable name for this entity",
           "type": "string"
+        },
+        "reservations": {
+          "description": "reservations for this size, which are considered during machine allocation",
+          "items": {
+            "$ref": "#/definitions/v1.SizeReservation"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -4545,6 +4588,13 @@
         "name": {
           "description": "a readable name for this entity",
           "type": "string"
+        },
+        "reservations": {
+          "description": "reservations for this size, which are considered during machine allocation",
+          "items": {
+            "$ref": "#/definitions/v1.SizeReservation"
+          },
+          "type": "array"
         }
       },
       "required": [


### PR DESCRIPTION
I think we once discussed this in the past but for some reason we said it's impossible to implement. I can't remember why anymore, so here is a suggestion.

This allows reserving machines of a specific size for projects in the the allocation process.

This is feature can be important for the operators to have some spare machines available, e.g. for updating Gardener Seed clusters while preventing regular users to allocate the last machines available in a partition. There are also use-cases where certain customers want to use a certain machine size exclusively, which can also be realized with this approach.

Unfortunately, just like the rack spreading, this algorithm is best-effort only. It can be tricked by heavy parallelization because we do not run the `findMachineCandidate` function in sync.