### PR TITLE
Allow adding labels to partitions.

### DIFF
--- a/cmd/metal-api/internal/metal/partition.go
+++ b/cmd/metal-api/internal/metal/partition.go
@@ -6,6 +6,7 @@ type Partition struct {
 	BootConfiguration          BootConfiguration `rethinkdb:"bootconfig" json:"bootconfig"`
 	MgmtServiceAddress         string            `rethinkdb:"mgmtserviceaddr" json:"mgmtserviceaddr"`
 	PrivateNetworkPrefixLength uint8             `rethinkdb:"privatenetworkprefixlength" json:"privatenetworkprefixlength"`
+	Labels                     map[string]string `rethinkdb:"labels" json:"labels"`
 }
 
 // BootConfiguration defines the metal-hammer initrd, kernel and commandline

--- a/cmd/metal-api/internal/service/partition-service.go
+++ b/cmd/metal-api/internal/service/partition-service.go
@@ -166,6 +166,10 @@ func (r *partitionResource) createPartition(request *restful.Request, response *
 	if requestPayload.MgmtServiceAddress != nil {
 		mgmtServiceAddress = *requestPayload.MgmtServiceAddress
 	}
+	labels := map[string]string{}
+	if requestPayload.Labels != nil {
+		labels = requestPayload.Labels
+	}
 	prefixLength := uint8(22)
 	if requestPayload.PrivateNetworkPrefixLength != nil {
 		prefixLength = uint8(*requestPayload.PrivateNetworkPrefixLength)
@@ -207,6 +211,7 @@ func (r *partitionResource) createPartition(request *restful.Request, response *
 			Name:        name,
 			Description: description,
 		},
+		Labels:                     labels,
 		MgmtServiceAddress:         mgmtServiceAddress,
 		PrivateNetworkPrefixLength: prefixLength,
 		BootConfiguration: metal.BootConfiguration{
@@ -273,6 +278,9 @@ func (r *partitionResource) updatePartition(request *restful.Request, response *
 	}
 	if requestPayload.MgmtServiceAddress != nil {
 		newPartition.MgmtServiceAddress = *requestPayload.MgmtServiceAddress
+	}
+	if requestPayload.Labels != nil {
+		newPartition.Labels = requestPayload.Labels
 	}
 	if requestPayload.PartitionBootConfiguration.ImageURL != nil {
 		err = checkImageURL("image", *requestPayload.PartitionBootConfiguration.ImageURL)

--- a/cmd/metal-api/internal/service/v1/partition.go
+++ b/cmd/metal-api/internal/service/v1/partition.go
@@ -5,8 +5,9 @@ import (
 )
 
 type PartitionBase struct {
-	MgmtServiceAddress         *string `json:"mgmtserviceaddress" description:"the address to the management service of this partition" optional:"true"`
-	PrivateNetworkPrefixLength *int    `json:"privatenetworkprefixlength" description:"the length of private networks for the machine's child networks in this partition, default 22" optional:"true" minimum:"16" maximum:"30"`
+	MgmtServiceAddress         *string           `json:"mgmtserviceaddress" description:"the address to the management service of this partition" optional:"true"`
+	PrivateNetworkPrefixLength *int              `json:"privatenetworkprefixlength" description:"the length of private networks for the machine's child networks in this partition, default 22" optional:"true" minimum:"16" maximum:"30"`
+	Labels                     map[string]string `json:"labels" description:"free labels that you associate with this partition" optional:"true"`
 }
 
 type PartitionBootConfiguration struct {
@@ -25,6 +26,7 @@ type PartitionUpdateRequest struct {
 	Common
 	MgmtServiceAddress         *string                     `json:"mgmtserviceaddress" description:"the address to the management service of this partition" optional:"true"`
 	PartitionBootConfiguration *PartitionBootConfiguration `json:"bootconfig" description:"the boot configuration of this partition" optional:"true"`
+	Labels                     map[string]string           `json:"labels" description:"free labels that you associate with this partition" optional:"true"`
 }
 
 type PartitionResponse struct {

--- a/cmd/metal-api/internal/service/v1/partition.go
+++ b/cmd/metal-api/internal/service/v1/partition.go
@@ -34,6 +34,7 @@ type PartitionResponse struct {
 	PartitionBase
 	PartitionBootConfiguration PartitionBootConfiguration `json:"bootconfig" description:"the boot configuration of this partition"`
 	Timestamps
+	Labels map[string]string `json:"labels" description:"free labels that you associate with this partition" optional:"true"`
 }
 
 type PartitionCapacityRequest struct {
@@ -89,6 +90,7 @@ func NewPartitionResponse(p *metal.Partition) *PartitionResponse {
 			Created: p.Created,
 			Changed: p.Changed,
 		},
+		Labels: p.Labels,
 	}
 }
 

--- a/cmd/metal-api/internal/service/v1/size.go
+++ b/cmd/metal-api/internal/service/v1/size.go
@@ -21,21 +21,21 @@ type SizeCreateRequest struct {
 	Common
 	SizeConstraints  []SizeConstraint  `json:"constraints" description:"a list of constraints that defines this size"`
 	SizeReservations []SizeReservation `json:"reservations,omitempty" description:"reservations for this size, which are considered during machine allocation" optional:"true"`
-	Labels           map[string]string `json:"labels" description:"free labels that you associate with this network." optional:"true"`
+	Labels           map[string]string `json:"labels" description:"free labels that you associate with this size." optional:"true"`
 }
 
 type SizeUpdateRequest struct {
 	Common
 	SizeConstraints  *[]SizeConstraint `json:"constraints" description:"a list of constraints that defines this size" optional:"true"`
 	SizeReservations []SizeReservation `json:"reservations,omitempty" description:"reservations for this size, which are considered during machine allocation" optional:"true"`
-	Labels           map[string]string `json:"labels" description:"free labels that you associate with this network." optional:"true"`
+	Labels           map[string]string `json:"labels" description:"free labels that you associate with this size." optional:"true"`
 }
 
 type SizeResponse struct {
 	Common
 	SizeConstraints  []SizeConstraint  `json:"constraints" description:"a list of constraints that defines this size"`
 	SizeReservations []SizeReservation `json:"reservations,omitempty" description:"reservations for this size, which are considered during machine allocation" optional:"true"`
-	Labels           map[string]string `json:"labels" description:"free labels that you associate with this network."`
+	Labels           map[string]string `json:"labels" description:"free labels that you associate with this size."`
 	Timestamps
 }
 

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -4381,7 +4381,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "free labels that you associate with this network.",
+          "description": "free labels that you associate with this size.",
           "type": "object"
         },
         "name": {
@@ -4639,7 +4639,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "free labels that you associate with this network.",
+          "description": "free labels that you associate with this size.",
           "type": "object"
         },
         "name": {
@@ -4693,7 +4693,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "free labels that you associate with this network.",
+          "description": "free labels that you associate with this size.",
           "type": "object"
         },
         "name": {

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -3848,6 +3848,13 @@
     },
     "v1.PartitionBase": {
       "properties": {
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "free labels that you associate with this partition",
+          "type": "object"
+        },
         "mgmtserviceaddress": {
           "description": "the address to the management service of this partition",
           "type": "string"
@@ -3933,6 +3940,13 @@
           "type": "string",
           "uniqueItems": true
         },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "free labels that you associate with this partition",
+          "type": "object"
+        },
         "mgmtserviceaddress": {
           "description": "the address to the management service of this partition",
           "type": "string"
@@ -3981,6 +3995,13 @@
           "type": "string",
           "uniqueItems": true
         },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "free labels that you associate with this partition",
+          "type": "object"
+        },
         "mgmtserviceaddress": {
           "description": "the address to the management service of this partition",
           "type": "string"
@@ -4016,6 +4037,13 @@
           "description": "the unique ID of this entity",
           "type": "string",
           "uniqueItems": true
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "free labels that you associate with this partition",
+          "type": "object"
         },
         "mgmtserviceaddress": {
           "description": "the address to the management service of this partition",


### PR DESCRIPTION
This can be useful to attach arbitrary information to a partition (in our case we need a speaking description of a region).