### PR TITLE
Introduce UUIDs for machine allocations.

### DIFF
--- a/cmd/metal-api/internal/datastore/migrations/05_allocation_uuids.go
+++ b/cmd/metal-api/internal/datastore/migrations/05_allocation_uuids.go
@@ -29,7 +29,7 @@ func init() {
 				}
 
 				newMachine := m
-				m.Allocation.UUID = uuid.New().String()
+				newMachine.Allocation.UUID = uuid.New().String()
 
 				err = rs.UpdateMachine(&m, &newMachine)
 				if err != nil {

--- a/cmd/metal-api/internal/datastore/migrations/05_allocation_uuids.go
+++ b/cmd/metal-api/internal/datastore/migrations/05_allocation_uuids.go
@@ -9,7 +9,7 @@ import (
 
 func init() {
 	datastore.MustRegisterMigration(datastore.Migration{
-		Name:    "generate allocation uuids allocated machines",
+		Name:    "generate allocation uuids for already allocated machines",
 		Version: 5,
 		Up: func(db *r.Term, session r.QueryExecutor, rs *datastore.RethinkStore) error {
 			machines, err := rs.ListMachines()

--- a/cmd/metal-api/internal/datastore/migrations/05_allocation_uuids.go
+++ b/cmd/metal-api/internal/datastore/migrations/05_allocation_uuids.go
@@ -1,0 +1,42 @@
+package migrations
+
+import (
+	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
+
+	"github.com/google/uuid"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
+)
+
+func init() {
+	datastore.MustRegisterMigration(datastore.Migration{
+		Name:    "generate allocation uuids allocated machines",
+		Version: 5,
+		Up: func(db *r.Term, session r.QueryExecutor, rs *datastore.RethinkStore) error {
+			machines, err := rs.ListMachines()
+			if err != nil {
+				return err
+			}
+
+			for _, m := range machines {
+				m := m
+
+				if m.Allocation == nil {
+					continue
+				}
+
+				if m.Allocation.UUID != "" {
+					continue
+				}
+
+				newMachine := m
+				m.Allocation.UUID = uuid.New().String()
+
+				err = rs.UpdateMachine(&m, &newMachine)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/cmd/metal-api/internal/metal/machine.go
+++ b/cmd/metal-api/internal/metal/machine.go
@@ -147,6 +147,7 @@ type MachineAllocation struct {
 	MachineSetup     *MachineSetup     `rethinkdb:"setup" json:"setup"`
 	Role             Role              `rethinkdb:"role" json:"role"`
 	VPN              *MachineVPN       `rethinkdb:"vpn" json:"vpn"`
+	UUID             string            `rethinkdb:"uuid" json:"uuid"`
 }
 
 // A MachineSetup stores the data used for machine reinstallations.

--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/headscale"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/issues"
 	"github.com/metal-stack/metal-lib/auditing"
@@ -1170,6 +1171,7 @@ func allocateMachine(logger *zap.SugaredLogger, ds *datastore.RethinkStore, ipam
 		MachineNetworks: []*metal.MachineNetwork{},
 		Role:            allocationSpec.Role,
 		VPN:             allocationSpec.VPN,
+		UUID:            uuid.New().String(),
 	}
 	rollbackOnError := func(err error) error {
 		if err != nil {

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -42,6 +42,7 @@ type MachineAllocation struct {
 	BootInfo         *BootInfo                 `json:"boot_info" description:"information required for booting the machine from HD" optional:"true"`
 	Role             string                    `json:"role" enum:"machine|firewall" description:"the role of the machine"`
 	VPN              *MachineVPN               `json:"vpn" description:"vpn connection info for machine" optional:"true"`
+	AllocationUUID   string                    `json:"allocationuuid" description:"a unique identifier for this machine allocation, can be used to distinguish between machine allocations over time."`
 }
 
 type BootInfo struct {
@@ -526,6 +527,7 @@ func NewMachineResponse(m *metal.Machine, s *metal.Size, p *metal.Partition, i *
 			FilesystemLayout: NewFilesystemLayoutResponse(m.Allocation.FilesystemLayout),
 			Role:             string(m.Allocation.Role),
 			VPN:              NewMachineVPN(m.Allocation.VPN),
+			AllocationUUID:   m.Allocation.UUID,
 		}
 
 		allocation.Reinstall = m.Allocation.Reinstall

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -1998,6 +1998,10 @@
     },
     "v1.MachineAllocation": {
       "properties": {
+        "allocationuuid": {
+          "description": "a unique identifier for this machine allocation, can be used to distinguish between machine allocations over time.",
+          "type": "string"
+        },
         "boot_info": {
           "$ref": "#/definitions/v1.BootInfo",
           "description": "information required for booting the machine from HD"
@@ -2076,6 +2080,7 @@
         }
       },
       "required": [
+        "allocationuuid",
         "created",
         "creator",
         "hostname",


### PR DESCRIPTION
This is mainly useful for accounting reasons to distinguish between machine allocations that happened over time.