### PR TITLE
remove dead code

### DIFF
--- a/cmd/metal-api/internal/service/image-service.go
+++ b/cmd/metal-api/internal/service/image-service.go
@@ -367,20 +367,6 @@ func (r *imageResource) deleteImage(request *restful.Request, response *restful.
 		return
 	}
 
-	ms, err := r.ds.ListMachines()
-	if err != nil {
-		r.sendError(request, response, defaultError(err))
-		return
-	}
-
-	machines := r.machinesByImage(ms, img.ID)
-	if len(machines) > 0 {
-		if err != nil {
-			r.sendError(request, response, httperrors.UnprocessableEntity(fmt.Errorf("image %s is in use by machines:%v", img.ID, machines)))
-			return
-		}
-	}
-
 	err = r.ds.DeleteImage(img)
 	if err != nil {
 		r.sendError(request, response, defaultError(err))

--- a/cmd/metal-api/internal/service/image-service.go
+++ b/cmd/metal-api/internal/service/image-service.go
@@ -367,6 +367,18 @@ func (r *imageResource) deleteImage(request *restful.Request, response *restful.
 		return
 	}
 
+	ms, err := r.ds.ListMachines()
+	if err != nil {
+		r.sendError(request, response, defaultError(err))
+		return
+	}
+
+	machines := r.machinesByImage(ms, img.ID)
+	if len(machines) > 0 {
+		r.sendError(request, response, httperrors.UnprocessableEntity(fmt.Errorf("image %s is in use by machines:%v", img.ID, machines)))
+		return
+	}
+
 	err = r.ds.DeleteImage(img)
 	if err != nil {
 		r.sendError(request, response, defaultError(err))

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -699,6 +699,11 @@ func (r *networkResource) deleteNetwork(request *restful.Request, response *rest
 		return
 	}
 
+	if len(children) != 0 {
+		r.sendError(request, response, defaultError(errors.New("network cannot be deleted because there are children of this network")))
+		return
+	}
+
 	allIPs, err := r.ds.ListIPs()
 	if err != nil {
 		r.sendError(request, response, defaultError(err))

--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -699,13 +699,6 @@ func (r *networkResource) deleteNetwork(request *restful.Request, response *rest
 		return
 	}
 
-	if len(children) != 0 {
-		if err != nil {
-			r.sendError(request, response, defaultError(errors.New("network cannot be deleted because there are children of this network")))
-			return
-		}
-	}
-
 	allIPs, err := r.ds.ListIPs()
 	if err != nil {
 		r.sendError(request, response, defaultError(err))


### PR DESCRIPTION
remove dead code.

in the image-service the result of `ListMachines` is only used later when doing the lookup via `machinesByImage`. But after this lookup we have a nested if-construct where the inner "if" is always false as it was checked a few lines above. so the `if len(machiens) ...` is alway an empty block and can be removed. so the whole `Listmachines` .

same in `network-service` as the `if err != nil` is always false.