### PR TITLE
Validate machine response against swagger spec.

### DIFF
--- a/cmd/metal-api/internal/service/machine-service_test.go
+++ b/cmd/metal-api/internal/service/machine-service_test.go
@@ -9,7 +9,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
+	"github.com/google/go-cmp/cmp"
 	goipam "github.com/metal-stack/go-ipam"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/ipam"
@@ -17,6 +22,7 @@ import (
 	v1 "github.com/metal-stack/metal-api/cmd/metal-api/internal/service/v1"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/testdata"
 	"github.com/metal-stack/metal-lib/bus"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
 	"github.com/metal-stack/security"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -1338,4 +1344,127 @@ func Test_gatherNetworksFromSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewMachineResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		m    *metal.Machine
+		s    *metal.Size
+		p    *metal.Partition
+		i    *metal.Image
+		ec   *metal.ProvisioningEventContainer
+		want *v1.MachineResponse
+	}{
+		{
+			name: "test firewall response",
+			m:    &testdata.FW1,
+			s:    &testdata.Sz1,
+			p:    &testdata.Partition1,
+			i:    &testdata.Img1,
+			ec:   &metal.ProvisioningEventContainer{},
+			want: &v1.MachineResponse{
+				Common: v1.Common{
+					Identifiable: v1.Identifiable{
+						ID: testdata.FW1.ID,
+					},
+					Describable: v1.Describable{
+						Name:        pointer.Pointer(""),
+						Description: pointer.Pointer(""),
+					},
+				},
+				MachineBase: v1.MachineBase{
+					Partition: v1.NewPartitionResponse(&testdata.Partition1),
+					RackID:    "",
+					Size:      v1.NewSizeResponse(&testdata.Sz1),
+					Hardware: v1.MachineHardware{
+						MachineHardwareBase: v1.MachineHardwareBase{
+							Memory:   testdata.FW1.Hardware.Memory,
+							CPUCores: testdata.FW1.Hardware.CPUCores,
+							Disks: []v1.MachineBlockDevice{
+								{
+									Size: testdata.FW1.Hardware.Disks[0].Size,
+								},
+								{
+									Size: testdata.FW1.Hardware.Disks[1].Size,
+								},
+								{
+									Size: testdata.FW1.Hardware.Disks[2].Size,
+								},
+							},
+						},
+						Nics: v1.MachineNics{},
+					},
+					Allocation: &v1.MachineAllocation{
+						Name:    testdata.FW1.Allocation.Name,
+						Project: testdata.FW1.Allocation.Project,
+						Image:   v1.NewImageResponse(&testdata.Img1),
+						MachineNetworks: []v1.MachineNetwork{
+							{
+								IPs:         []string{},
+								NetworkType: "privateprimaryunshared",
+								Vrf:         1,
+								Private:     true,
+							},
+						},
+						Role: "firewall",
+						FirewallRules: &v1.FirewallRules{
+							Egress: []v1.FirewallEgressRule{
+								{
+									Protocol: "tcp",
+									Ports:    []int{443},
+									To:       []string{"0.0.0.0/0"},
+									Comment:  "test",
+								},
+							},
+							Ingress: nil,
+						},
+					},
+					RecentProvisioningEvents: v1.MachineRecentProvisioningEvents{
+						Events: []v1.MachineProvisioningEvent{},
+					},
+					Tags: testdata.FW1.Tags,
+				},
+				Timestamps: v1.Timestamps{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := v1.NewMachineResponse(tt.m, tt.s, tt.p, tt.i, tt.ec)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+
+			ws, err := NewMachine(slog.Default(), nil, &emptyPublisher{}, bus.DirectEndpoints(), ipam.New(nil), nil, nil, nil, 0, nil, metal.DisabledIPMISuperUser())
+			require.NoError(t, err)
+
+			validateAgainstSwaggerSpec(t, ws, "v1.MachineResponse", got)
+		})
+	}
+}
+
+func validateAgainstSwaggerSpec(t *testing.T, ws *restful.WebService, definitionKey string, obj any) {
+	container := restful.NewContainer()
+	container.Add(ws)
+
+	actual := restfulspec.BuildSwagger(restfulspec.Config{
+		WebServices: container.RegisteredWebServices(),
+	})
+
+	schemaJSON, err := json.MarshalIndent(actual, "", "  ")
+	require.NoError(t, err)
+
+	schema := new(spec.Schema)
+	err = json.Unmarshal(schemaJSON, schema)
+	require.NoError(t, err)
+
+	// you need to pass the definition of the response to the validator otherwise it will not find any problems
+	def, ok := schema.Definitions[definitionKey]
+	require.True(t, ok)
+
+	def.Definitions = schema.Definitions
+
+	err = validate.AgainstSchema(&def, obj, strfmt.Default, validate.EnableArrayMustHaveItemsCheck(true), validate.EnableObjectArrayTypeCheck(true))
+	require.NoError(t, err)
 }

--- a/cmd/metal-api/internal/service/v1/image.go
+++ b/cmd/metal-api/internal/service/v1/image.go
@@ -12,7 +12,7 @@ type ImageBase struct {
 	Features       []string  `json:"features" description:"features of this image" optional:"true"`
 	ExpirationDate time.Time `json:"expirationDate" description:"expirationDate of this image" optional:"false"`
 	Classification string    `json:"classification" description:"classification of this image" optional:"true"`
-	UsedBy         []string  `json:"usedby" description:"machines where this image is in use" optional:"true"`
+	UsedBy         []string  `json:"usedby,omitempty" description:"machines where this image is in use" optional:"true"`
 }
 
 type ImageCreateRequest struct {

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -36,7 +36,7 @@ type MachineAllocation struct {
 	FilesystemLayout *FilesystemLayoutResponse `json:"filesystemlayout" description:"filesystemlayout to create on this machine" optional:"true"`
 	MachineNetworks  []MachineNetwork          `json:"networks" description:"the networks of this machine"`
 	Hostname         string                    `json:"hostname" description:"the hostname which will be used when creating the machine"`
-	SSHPubKeys       []string                  `json:"ssh_pub_keys" description:"the public ssh keys to access the machine with"`
+	SSHPubKeys       []string                  `json:"ssh_pub_keys,omitempty" description:"the public ssh keys to access the machine with"`
 	UserData         string                    `json:"user_data,omitempty" description:"userdata to execute post installation tasks" optional:"true"`
 	Succeeded        bool                      `json:"succeeded" description:"if the allocation of the machine was successful, this is set to true"`
 	Reinstall        bool                      `json:"reinstall" description:"indicates whether to reinstall the machine"`
@@ -64,9 +64,9 @@ type BootInfo struct {
 
 type MachineNetwork struct {
 	NetworkID           string   `json:"networkid" description:"the networkID of the allocated machine in this vrf"`
-	Prefixes            []string `json:"prefixes" description:"the prefixes of this network"`
-	IPs                 []string `json:"ips" description:"the ip addresses of the allocated machine in this vrf"`
-	DestinationPrefixes []string `json:"destinationprefixes" modelDescription:"prefixes that are reachable within this network" description:"the destination prefixes of this network"`
+	Prefixes            []string `json:"prefixes,omitempty" description:"the prefixes of this network"`
+	IPs                 []string `json:"ips,omitempty" description:"the ip addresses of the allocated machine in this vrf"`
+	DestinationPrefixes []string `json:"destinationprefixes,omitempty" modelDescription:"prefixes that are reachable within this network" description:"the destination prefixes of this network"`
 	NetworkType         string   `json:"networktype" description:"the network type, types can be looked up in the network package of metal-lib"`
 	Vrf                 uint     `json:"vrf" description:"the vrf of the allocated machine"`
 	// Attention, uint32 is converted to integer by swagger which is int32 which is to small to hold a asn
@@ -112,7 +112,7 @@ type MachineBlockDevice struct {
 
 type MachineRecentProvisioningEvents struct {
 	Events               []MachineProvisioningEvent `json:"log" description:"the log of recent machine provisioning events"`
-	LastEventTime        *time.Time                 `json:"last_event_time" description:"the time where the last event was received" optional:"true"`
+	LastEventTime        *time.Time                 `json:"last_event_time,omitempty" description:"the time where the last event was received" optional:"true"`
 	LastErrorEvent       *MachineProvisioningEvent  `json:"last_error_event,omitempty" description:"the last erroneous event received" optional:"true"`
 	CrashLoop            bool                       `json:"crash_loop" description:"indicates that machine is provisioning crash loop"`
 	FailedMachineReclaim bool                       `json:"failed_machine_reclaim" description:"indicates that machine reclaim has failed"`
@@ -199,7 +199,7 @@ type MachineAllocateRequest struct {
 	SizeID             string                    `json:"sizeid" description:"the size id to assign this machine to"`
 	ImageID            string                    `json:"imageid" description:"the image id to assign this machine to"`
 	FilesystemLayoutID *string                   `json:"filesystemlayoutid" description:"the filesystemlayout id to assing to this machine" optional:"true"`
-	SSHPubKeys         []string                  `json:"ssh_pub_keys" description:"the public ssh keys to access the machine with"`
+	SSHPubKeys         []string                  `json:"ssh_pub_keys,omitempty" description:"the public ssh keys to access the machine with"`
 	UserData           *string                   `json:"user_data" description:"cloud-init.io compatible userdata must be base64 encoded" optional:"true"`
 	Tags               []string                  `json:"tags" description:"tags for this machine" optional:"true"`
 	Networks           MachineAllocationNetworks `json:"networks" description:"the networks that this machine will be placed in." optional:"true"`

--- a/cmd/metal-api/internal/testdata/testdata.go
+++ b/cmd/metal-api/internal/testdata/testdata.go
@@ -26,6 +26,54 @@ import (
 // (go tool cover -html=cover.out -o cover.html) 	// Html output
 
 var (
+	// Firewalls
+	FW1 = metal.Machine{
+		Base:        metal.Base{ID: "1"},
+		PartitionID: "1",
+		SizeID:      "1",
+		Allocation: &metal.MachineAllocation{
+			Name:    "d1",
+			ImageID: "image-1",
+			Project: "p1",
+			Role:    metal.RoleFirewall,
+			MachineNetworks: []*metal.MachineNetwork{
+				{
+					Private: true,
+					Vrf:     1,
+				},
+			},
+			FirewallRules: &metal.FirewallRules{
+				Egress: []metal.EgressRule{
+					{
+						Protocol: metal.ProtocolTCP,
+						Ports:    []int{443},
+						To:       []string{"0.0.0.0/0"},
+						Comment:  "test",
+					},
+				},
+				Ingress: []metal.IngressRule{},
+			},
+		},
+		Hardware: metal.MachineHardware{
+			CPUCores: 8,
+			Memory:   1 << 30,
+			Disks: []metal.BlockDevice{
+				{
+					Size: 1000,
+				},
+				{
+					Size: 1000,
+				},
+				{
+					Size: 1000,
+				},
+			},
+		},
+
+		IPMI: IPMI1,
+		Tags: []string{"1"},
+	}
+
 	// Machines
 	M1 = metal.Machine{
 		Base:        metal.Base{ID: "1"},

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/emicklei/go-restful-openapi/v2 v2.9.1
 	github.com/emicklei/go-restful/v3 v3.11.3
 	github.com/go-openapi/spec v0.21.0
+	github.com/go-openapi/validate v0.24.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0
@@ -77,11 +78,13 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
+	github.com/go-openapi/loads v0.22.0 // indirect
 	github.com/go-openapi/runtime v0.28.0 // indirect
-	github.com/go-openapi/strfmt v0.23.0 // indirect
+	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gofrs/uuid/v5 v5.0.0 // indirect

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -1105,8 +1105,7 @@
         "imageid",
         "partitionid",
         "projectid",
-        "sizeid",
-        "ssh_pub_keys"
+        "sizeid"
       ]
     },
     "v1.FirewallEgressRule": {
@@ -2080,8 +2079,7 @@
         "imageid",
         "partitionid",
         "projectid",
-        "sizeid",
-        "ssh_pub_keys"
+        "sizeid"
       ]
     },
     "v1.MachineAllocation": {
@@ -2181,7 +2179,6 @@
         "project",
         "reinstall",
         "role",
-        "ssh_pub_keys",
         "succeeded"
       ]
     },
@@ -3153,12 +3150,9 @@
       },
       "required": [
         "asn",
-        "destinationprefixes",
-        "ips",
         "nat",
         "networkid",
         "networktype",
-        "prefixes",
         "private",
         "underlay",
         "vrf"


### PR DESCRIPTION
We often produce responses with our server that are not valid against the Swagger spec. For Go clients this seems not to be a big issue as type safety is guaranteed and it's not possible to produce server responses that violate type constraints. For other clients like Python there are much stricter validations though.