### PR TITLE
Update metal-lib to v0.16.1.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/looplab/fsm v0.3.0
 	github.com/metal-stack/go-ipam v1.8.5
 	github.com/metal-stack/masterdata-api v0.11.1
-	github.com/metal-stack/metal-lib v0.16.0
+	github.com/metal-stack/metal-lib v0.16.1
 	github.com/metal-stack/security v0.8.0
 	github.com/metal-stack/v v1.0.3
 	github.com/nsqio/go-nsq v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/metal-stack/go-ipam v1.8.5 h1:XE1XfaU6Ck1Ucc7svTO25dlT7kEcE1oxOM3lBrW
 github.com/metal-stack/go-ipam v1.8.5/go.mod h1:JgsddJabu8A7lWD+4MJKqbQhmSA/zhBbO+Bp8pLhRZM=
 github.com/metal-stack/masterdata-api v0.11.1 h1:RRlML1bUS+aoPgMwbqWQazrlMOlLy2QbUoDwoUAJ6kY=
 github.com/metal-stack/masterdata-api v0.11.1/go.mod h1:9T0UUAWU0+G2jKRFuA1mlTS2vexWiGdaBj1AJQGFQ6Q=
-github.com/metal-stack/metal-lib v0.16.0 h1:Zbxq1Qf2H5OKvmSowlVZ5d+sQqIBtiyACeKHvvK3vJg=
-github.com/metal-stack/metal-lib v0.16.0/go.mod h1:nyNGI4DZFOcWbSoq2Y6V3SHpFxuXBIqYBZHTb6cy//s=
+github.com/metal-stack/metal-lib v0.16.1 h1:4iw2cQxS1pcQnuTVlXRvtmR0oCa6OCX6rIiZalfwSZY=
+github.com/metal-stack/metal-lib v0.16.1/go.mod h1:nyNGI4DZFOcWbSoq2Y6V3SHpFxuXBIqYBZHTb6cy//s=
 github.com/metal-stack/security v0.8.0 h1:tVaSDB9m5clwYrnLyaXfPy7mQlJTnmeoHscG+RUy/xo=
 github.com/metal-stack/security v0.8.0/go.mod h1:7GAcQb+pOgflW30ohJygxpqc3i0dQ2ahGJK1CU5tqa0=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -369,7 +369,6 @@
       },
       "required": [
         "message",
-        "services",
         "status"
       ]
     },
@@ -390,7 +389,6 @@
       },
       "required": [
         "message",
-        "services",
         "status"
       ]
     },


### PR DESCRIPTION
Fixes integration tests for metal-stack: https://github.com/metal-stack/releases/actions/runs/8520376426/job/23336369417