### PR TITLE
Fix for identifier matching with filepath.

### DIFF
--- a/cmd/metal-api/internal/metal/machine.go
+++ b/cmd/metal-api/internal/metal/machine.go
@@ -496,12 +496,12 @@ func capacityOf[V any](identifier string, vs []V, countFn func(v V) (model strin
 		matched []V
 	)
 
-	if identifier == "" {
-		identifier = "*"
-	}
-
 	for _, v := range vs {
 		model, count := countFn(v)
+
+		if identifier == "" {
+			model = ""
+		}
 
 		matches, err := filepath.Match(identifier, model)
 		if err != nil {


### PR DESCRIPTION
Unfortunately, filepath matching behavior is especially made for filepaths. :D 

See: https://go.dev/play/p/HcMippvYpw2