### PR TITLE
Fix size overlapping not checked symmetrically

### DIFF
--- a/cmd/metal-api/internal/grpc/boot-service_test.go
+++ b/cmd/metal-api/internal/grpc/boot-service_test.go
@@ -119,7 +119,11 @@ func TestBootService_Register(t *testing.T) {
 				Uuid: tt.uuid,
 				Hardware: &v1.MachineHardware{
 					Memory: uint64(tt.memory),
-
+					Disks: []*v1.MachineBlockDevice{
+						{
+							Size: 1000000000000,
+						},
+					},
 					Cpus: []*v1.MachineCPU{
 						{
 							Model:   "Intel Xeon Silver",

--- a/cmd/metal-api/internal/metal/size.go
+++ b/cmd/metal-api/internal/metal/size.go
@@ -61,6 +61,10 @@ func countDisk(disk BlockDevice) (model string, count uint64) {
 	return disk.Name, disk.Size
 }
 
+func countMemory(size uint64) (model string, count uint64) {
+	return "", size
+}
+
 // Sizes is a list of sizes.
 type Sizes []Size
 
@@ -114,9 +118,6 @@ func (c *Constraint) matches(hw MachineHardware) bool {
 // With this we ensure that hardware matches exhaustive against the constraints.
 func (hw *MachineHardware) matches(constraints []Constraint, constraintType ConstraintType) bool {
 	filtered := lo.Filter(constraints, func(c Constraint, _ int) bool { return c.Type == constraintType })
-	if len(filtered) == 0 {
-		return true
-	}
 
 	switch constraintType {
 	case StorageConstraint:
@@ -126,10 +127,9 @@ func (hw *MachineHardware) matches(constraints []Constraint, constraintType Cons
 	case CoreConstraint:
 		return exhaustiveMatch(filtered, hw.MetalCPUs, countCPU)
 	case MemoryConstraint:
-		// Noop because we do not have different Memory types
-		return true
+		return exhaustiveMatch(filtered, []uint64{hw.Memory}, countMemory)
 	default:
-		return true
+		return false
 	}
 }
 

--- a/cmd/metal-api/internal/metal/size.go
+++ b/cmd/metal-api/internal/metal/size.go
@@ -168,21 +168,37 @@ nextsize:
 }
 
 func (s *Size) overlaps(so *Size) bool {
-	if len(lo.FromPtr(so).Constraints) == 0 {
+	if len(lo.FromPtr(so).Constraints) == 0 || len(lo.FromPtr(s).Constraints) == 0 {
 		return false
 	}
+
 	srcTypes := lo.GroupBy(s.Constraints, func(item Constraint) ConstraintType {
 		return item.Type
 	})
 	destTypes := lo.GroupBy(so.Constraints, func(item Constraint) ConstraintType {
 		return item.Type
 	})
+
 	for t, srcConstraints := range srcTypes {
 		constraints, ok := destTypes[t]
 		if !ok {
 			return false
 		}
 		for _, sc := range srcConstraints {
+			for _, c := range constraints {
+				if !c.overlaps(sc) {
+					return false
+				}
+			}
+		}
+	}
+
+	for t, destConstraints := range destTypes {
+		constraints, ok := srcTypes[t]
+		if !ok {
+			return false
+		}
+		for _, sc := range destConstraints {
 			for _, c := range constraints {
 				if !c.overlaps(sc) {
 					return false

--- a/cmd/metal-api/internal/metal/size_test.go
+++ b/cmd/metal-api/internal/metal/size_test.go
@@ -907,50 +907,8 @@ func TestSizes_Overlaps(t *testing.T) {
 				},
 			},
 			sizes: Sizes{
-				Size{
-					Base: Base{
-						ID: "micro",
-					},
-					Constraints: []Constraint{
-						{
-							Type: CoreConstraint,
-							Min:  1,
-							Max:  1,
-						},
-						{
-							Type: MemoryConstraint,
-							Min:  1024,
-							Max:  1024,
-						},
-						{
-							Type: StorageConstraint,
-							Min:  0,
-							Max:  1024,
-						},
-					},
-				},
-				Size{
-					Base: Base{
-						ID: "tiny",
-					},
-					Constraints: []Constraint{
-						{
-							Type: CoreConstraint,
-							Min:  1,
-							Max:  1,
-						},
-						{
-							Type: MemoryConstraint,
-							Min:  1025,
-							Max:  1077838336,
-						},
-						{
-							Type: StorageConstraint,
-							Min:  1024,
-							Max:  2048,
-						},
-					},
-				},
+				microSize,
+				tinySize,
 				Size{
 					Base: Base{
 						ID: "large",
@@ -974,7 +932,7 @@ func TestSizes_Overlaps(t *testing.T) {
 					},
 				},
 			},
-			want: &microSize,
+			want: nil,
 		},
 
 		{

--- a/cmd/metal-api/internal/metal/size_test.go
+++ b/cmd/metal-api/internal/metal/size_test.go
@@ -270,6 +270,11 @@ var (
 				Min:        1,
 				Max:        1,
 			},
+			{
+				Type: MemoryConstraint,
+				Min:  2048,
+				Max:  2048,
+			},
 		},
 	}
 	amdCPUSize = Size{
@@ -282,6 +287,11 @@ var (
 				Identifier: "AMD Ryzen*",
 				Min:        1,
 				Max:        1,
+			},
+			{
+				Type: MemoryConstraint,
+				Min:  2048,
+				Max:  2048,
 			},
 		},
 	}
@@ -636,6 +646,7 @@ func TestSizes_FromHardware(t *testing.T) {
 							Threads: 1,
 						},
 					},
+					Memory: 2048,
 				},
 			},
 			want:    &intelCPUSize,
@@ -656,6 +667,7 @@ func TestSizes_FromHardware(t *testing.T) {
 							Threads: 1,
 						},
 					},
+					Memory: 2048,
 				},
 			},
 			want:    &amdCPUSize,
@@ -686,6 +698,68 @@ func TestSizes_FromHardware(t *testing.T) {
 				},
 			},
 			want:    &miniLabSize,
+			wantErr: false,
+		},
+		{
+			name: "memory exhaustive check",
+			sz: Sizes{
+				{
+					Base: Base{
+						ID: "without core constraint",
+					},
+					Constraints: []Constraint{
+						{
+							Type: MemoryConstraint,
+							Min:  2147483648,
+							Max:  2147483648,
+						},
+					},
+				},
+				{
+					Base: Base{
+						ID: "with core constraint",
+					},
+					Constraints: []Constraint{
+						{
+							Type: MemoryConstraint,
+							Min:  2147483648,
+							Max:  2147483648,
+						},
+						{
+							Type: CoreConstraint,
+							Min:  1,
+							Max:  1,
+						},
+					},
+				},
+			},
+			args: args{
+				hardware: MachineHardware{
+					MetalCPUs: []MetalCPU{
+						{
+							Cores: 1,
+						},
+					},
+					Memory: 2147483648,
+				},
+			},
+			want: &Size{
+				Base: Base{
+					ID: "with core constraint",
+				},
+				Constraints: []Constraint{
+					{
+						Type: MemoryConstraint,
+						Min:  2147483648,
+						Max:  2147483648,
+					},
+					{
+						Type: CoreConstraint,
+						Min:  1,
+						Max:  1,
+					},
+				},
+			},
 			wantErr: false,
 		},
 	}

--- a/cmd/metal-api/internal/metal/size_test.go
+++ b/cmd/metal-api/internal/metal/size_test.go
@@ -1536,7 +1536,6 @@ func TestConstraint_overlaps(t *testing.T) {
 			},
 			want: true,
 		},
-
 		{
 			name: "partial overlap, in range",
 			this: Constraint{
@@ -1582,10 +1581,10 @@ func TestConstraint_overlaps(t *testing.T) {
 
 func TestSize_overlaps(t *testing.T) {
 	tests := []struct {
-		name  string
-		this  *Size
-		other *Size
-		want  bool
+		name        string
+		this        *Size
+		other       *Size
+		wantOverlap bool
 	}{
 		{
 			name: "no overlap, different types",
@@ -1599,9 +1598,8 @@ func TestSize_overlaps(t *testing.T) {
 					{Type: CoreConstraint},
 				},
 			},
-			want: false,
+			wantOverlap: false,
 		},
-
 		{
 			name: "no overlap, different identifiers",
 			this: &Size{
@@ -1614,9 +1612,8 @@ func TestSize_overlaps(t *testing.T) {
 					{Type: MemoryConstraint, Identifier: "b"},
 				},
 			},
-			want: false,
+			wantOverlap: false,
 		},
-
 		{
 			name: "no overlap, different range",
 			this: &Size{
@@ -1629,9 +1626,8 @@ func TestSize_overlaps(t *testing.T) {
 					{Type: MemoryConstraint, Identifier: "a", Min: 5, Max: 8},
 				},
 			},
-			want: false,
+			wantOverlap: false,
 		},
-
 		{
 			name: "no overlap, different gpus",
 			this: &Size{
@@ -1645,9 +1641,8 @@ func TestSize_overlaps(t *testing.T) {
 					{Type: GPUConstraint, Identifier: "b", Min: 2, Max: 2},
 				},
 			},
-			want: false,
+			wantOverlap: false,
 		},
-
 		{
 			name: "overlapping size",
 			this: &Size{
@@ -1688,7 +1683,7 @@ func TestSize_overlaps(t *testing.T) {
 					},
 				},
 			},
-			want: true,
+			wantOverlap: true,
 		},
 		{
 			name: "non overlapping size",
@@ -1732,7 +1727,7 @@ func TestSize_overlaps(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			wantOverlap: false,
 		},
 		{
 			name: "overlap, all the same",
@@ -1750,13 +1745,121 @@ func TestSize_overlaps(t *testing.T) {
 					{Type: MemoryConstraint, Identifier: "a", Min: 5, Max: 8},
 				},
 			},
-			want: true,
+			wantOverlap: true,
+		},
+		{
+			name: "independent of order #1",
+			this: &Size{
+				Base: Base{
+					ID: "g1-medium-x86",
+				},
+				Constraints: []Constraint{
+					{
+						Type: CoreConstraint,
+						Min:  32,
+						Max:  32,
+					},
+					{
+						Type: MemoryConstraint,
+						Min:  257698037760,
+						Max:  300647710720,
+					},
+					{
+						Type: StorageConstraint,
+						Min:  1500000000000,
+						Max:  2000000000000,
+					},
+					{
+						Type:       GPUConstraint,
+						Min:        1,
+						Max:        1,
+						Identifier: "AD102GL*",
+					},
+				},
+			},
+			other: &Size{
+				Base: Base{
+					ID: "c2-xlarge-x86",
+				},
+				Constraints: []Constraint{
+					{
+						Type: CoreConstraint,
+						Min:  32,
+						Max:  32,
+					},
+					{
+						Type: MemoryConstraint,
+						Min:  220000000000,
+						Max:  280000000000,
+					},
+					{
+						Type: StorageConstraint,
+						Min:  500000000000,
+						Max:  4000000000000,
+					},
+				},
+			},
+			wantOverlap: false,
+		},
+		{
+			name: "independent of order #2",
+			this: &Size{
+				Base: Base{
+					ID: "c2-xlarge-x86",
+				},
+				Constraints: []Constraint{
+					{
+						Type: CoreConstraint,
+						Min:  32,
+						Max:  32,
+					},
+					{
+						Type: MemoryConstraint,
+						Min:  220000000000,
+						Max:  280000000000,
+					},
+					{
+						Type: StorageConstraint,
+						Min:  500000000000,
+						Max:  4000000000000,
+					},
+				},
+			},
+			other: &Size{
+				Base: Base{
+					ID: "g1-medium-x86",
+				},
+				Constraints: []Constraint{
+					{
+						Type: CoreConstraint,
+						Min:  32,
+						Max:  32,
+					},
+					{
+						Type: MemoryConstraint,
+						Min:  257698037760,
+						Max:  300647710720,
+					},
+					{
+						Type: StorageConstraint,
+						Min:  1500000000000,
+						Max:  2000000000000,
+					},
+					{
+						Type:       GPUConstraint,
+						Min:        1,
+						Max:        1,
+						Identifier: "AD102GL*",
+					},
+				},
+			},
+			wantOverlap: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.this.overlaps(tt.other); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Size.Overlaps() = %v, want %v", got, tt.want)
+			if got := tt.this.overlaps(tt.other); !reflect.DeepEqual(got, tt.wantOverlap) {
+				t.Errorf("Size.Overlaps() = %v, want %v", got, tt.wantOverlap)
 			}
 		})
 	}

--- a/cmd/metal-api/internal/service/size-service.go
+++ b/cmd/metal-api/internal/service/size-service.go
@@ -306,7 +306,7 @@ func (r *sizeResource) createSize(request *restful.Request, response *restful.Re
 	}
 
 	if so := s.Overlaps(&ss); so != nil {
-		r.sendError(request, response, httperrors.BadRequest(fmt.Errorf("size overlaps with %q", so.GetID())))
+		r.sendError(request, response, httperrors.BadRequest(fmt.Errorf("size %q overlaps with %q", s.GetID(), so.GetID())))
 		return
 	}
 
@@ -414,7 +414,7 @@ func (r *sizeResource) updateSize(request *restful.Request, response *restful.Re
 	}
 
 	if so := newSize.Overlaps(&ss); so != nil {
-		r.sendError(request, response, httperrors.BadRequest(fmt.Errorf("size overlaps with %q", so.GetID())))
+		r.sendError(request, response, httperrors.BadRequest(fmt.Errorf("size %q overlaps with %q", newSize.GetID(), so.GetID())))
 		return
 	}
 

--- a/cmd/metal-api/internal/testdata/testdata.go
+++ b/cmd/metal-api/internal/testdata/testdata.go
@@ -184,6 +184,11 @@ var (
 				Min:  100,
 				Max:  100,
 			},
+			{
+				Type: metal.StorageConstraint,
+				Min:  1000000000000,
+				Max:  1000000000000,
+			},
 		},
 		Reservations: metal.Reservations{
 			{


### PR DESCRIPTION
This is potentially a breaking change if people have sizes in their database that are specified incompletely against the hardware, e.g. if they have a size with only memory and core constraint and the hardware is reported by the metal-hammer with disks. With this change the size will not be matched anymore and the storage constraint matching the reported hardware needs to be added.

```ACTIONS_REQUIRED
The reported hardware is now exhaustively checked against the size constraints. In general this implies that core, memory and storage constraints always need to be specified in the size constraints. If this is missing in any of your defined sizes, please adapt those accordingly.
```