### PR TITLE
Fix bug on checking headscale connection.

### DIFF
--- a/cmd/metal-api/internal/headscale/client.go
+++ b/cmd/metal-api/internal/headscale/client.go
@@ -111,19 +111,12 @@ func (h *HeadscaleClient) CreatePreAuthKey(ctx context.Context, user string, exp
 	return resp.PreAuthKey.Key, nil
 }
 
-type connectedMap map[string]bool
-
-func (h *HeadscaleClient) MachinesConnected(ctx context.Context) (connectedMap, error) {
+func (h *HeadscaleClient) MachinesConnected(ctx context.Context) ([]*headscalev1.Machine, error) {
 	resp, err := h.client.ListMachines(ctx, &headscalev1.ListMachinesRequest{})
 	if err != nil || resp == nil {
 		return nil, fmt.Errorf("failed to list machines: %w", err)
 	}
-	result := connectedMap{}
-	for _, m := range resp.Machines {
-		result[m.Name] = m.Online
-	}
-
-	return result, nil
+	return resp.Machines, nil
 }
 
 // DeleteMachine removes the node entry from headscale DB

--- a/cmd/metal-api/internal/headscale/client.go
+++ b/cmd/metal-api/internal/headscale/client.go
@@ -116,6 +116,7 @@ func (h *HeadscaleClient) MachinesConnected(ctx context.Context) ([]*headscalev1
 	if err != nil || resp == nil {
 		return nil, fmt.Errorf("failed to list machines: %w", err)
 	}
+
 	return resp.Machines, nil
 }
 

--- a/cmd/metal-api/internal/service/vpn-service.go
+++ b/cmd/metal-api/internal/service/vpn-service.go
@@ -131,7 +131,7 @@ func EvaluateVPNConnected(log *slog.Logger, ds *datastore.RethinkStore, lister h
 			continue
 		}
 
-		connected := slices.ContainsFunc(headscaleMachines, func(hm *headscalev1.Machine) bool {
+		index := slices.IndexFunc(headscaleMachines, func(hm *headscalev1.Machine) bool {
 			if hm.Name != m.ID {
 				return false
 			}
@@ -140,12 +140,14 @@ func EvaluateVPNConnected(log *slog.Logger, ds *datastore.RethinkStore, lister h
 				return false
 			}
 
-			if !hm.Online {
-				return false
-			}
-
 			return true
 		})
+
+		if index < 0 {
+			continue
+		}
+
+		connected := headscaleMachines[index].Online
 
 		if m.Allocation.VPN.Connected == connected {
 			log.Info("not updating vpn because already up-to-date", "machine", m.ID, "connected", connected)

--- a/cmd/metal-api/internal/service/vpn-service.go
+++ b/cmd/metal-api/internal/service/vpn-service.go
@@ -1,18 +1,23 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"time"
 
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 
 	"github.com/emicklei/go-restful/v3"
 
+	headscalev1 "github.com/juanfont/headscale/gen/go/headscale/v1"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/headscale"
 	v1 "github.com/metal-stack/metal-api/cmd/metal-api/internal/service/v1"
 	"github.com/metal-stack/metal-lib/httperrors"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
 )
 
 type vpnResource struct {
@@ -99,4 +104,70 @@ func (r *vpnResource) getVPNAuthKey(request *restful.Request, response *restful.
 	}
 
 	r.send(request, response, http.StatusOK, authKeyResp)
+}
+
+type headscaleMachineLister interface {
+	MachinesConnected(ctx context.Context) ([]*headscalev1.Machine, error)
+}
+
+func EvaluateVPNConnected(log *slog.Logger, ds *datastore.RethinkStore, lister headscaleMachineLister) error {
+	ms, err := ds.ListMachines()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	headscaleMachines, err := lister.MachinesConnected(ctx)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, m := range ms {
+		m := m
+		if m.Allocation == nil || m.Allocation.VPN == nil {
+			continue
+		}
+
+		connected := slices.ContainsFunc(headscaleMachines, func(hm *headscalev1.Machine) bool {
+			if hm.Name != m.ID {
+				return false
+			}
+
+			if pointer.SafeDeref(hm.User).Name != m.Allocation.Project {
+				return false
+			}
+
+			if !hm.Online {
+				return false
+			}
+
+			return true
+		})
+
+		if m.Allocation.VPN.Connected == connected {
+			log.Info("not updating vpn because already up-to-date", "machine", m.ID, "connected", connected)
+			continue
+		}
+
+		old := m
+		m.Allocation.VPN.Connected = connected
+
+		err := ds.UpdateMachine(&old, &m)
+		if err != nil {
+			errs = append(errs, err)
+			log.Error("unable to update vpn connected state, continue anyway", "machine", m.ID, "error", err)
+			continue
+		}
+
+		log.Info("updated vpn connected state", "machine", m.ID, "connected", connected)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors occurred when evaluating machine vpn connections")
+	}
+
+	return nil
 }

--- a/cmd/metal-api/internal/service/vpn-service_test.go
+++ b/cmd/metal-api/internal/service/vpn-service_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	headscalev1 "github.com/juanfont/headscale/gen/go/headscale/v1"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/datastore"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
+	"github.com/metal-stack/metal-api/cmd/metal-api/internal/testdata"
+	"github.com/metal-stack/metal-lib/pkg/testcommon"
+	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
+)
+
+func Test_EvaluateVPNConnected(t *testing.T) {
+	tests := []struct {
+		name              string
+		mockFn            func(mock *r.Mock)
+		headscaleMachines []*headscalev1.Machine
+		wantErr           error
+	}{
+		{
+			name: "machines are correctly evaluated",
+			mockFn: func(mock *r.Mock) {
+				mock.On(r.DB("mockdb").Table("machine")).Return(metal.Machines{
+					{
+						Base: metal.Base{
+							ID: "toggle",
+						},
+						Allocation: &metal.MachineAllocation{
+							Project: "p1",
+							VPN: &metal.MachineVPN{
+								Connected: false,
+							},
+						},
+					},
+					{
+						Base: metal.Base{
+							ID: "already-connected",
+						},
+						Allocation: &metal.MachineAllocation{
+							Project: "p2",
+							VPN: &metal.MachineVPN{
+								Connected: true,
+							},
+						},
+					},
+					{
+						Base: metal.Base{
+							ID: "no-vpn",
+						},
+						Allocation: &metal.MachineAllocation{
+							Project: "p3",
+						},
+					},
+				}, nil)
+
+				// unfortunately, it's too hard to check the replace exactly for specific fields...
+				mock.On(r.DB("mockdb").Table("machine").Get("toggle").Replace(r.MockAnything())).Return(testdata.EmptyResult, nil)
+			},
+			headscaleMachines: []*headscalev1.Machine{
+				{
+					Name: "toggle",
+					User: &headscalev1.User{
+						Name: "previous-allocation",
+					},
+					Online: false,
+				},
+				{
+					Name: "toggle",
+					User: &headscalev1.User{
+						Name: "p1",
+					},
+					Online: true,
+				},
+				{
+					Name: "already-connected",
+					User: &headscalev1.User{
+						Name: "p2",
+					},
+					Online: true,
+				},
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, mock := datastore.InitMockDB(t)
+			if tt.mockFn != nil {
+				tt.mockFn(mock)
+			}
+
+			err := EvaluateVPNConnected(slog.Default(), ds, &headscaleTest{ms: tt.headscaleMachines})
+			if diff := cmp.Diff(tt.wantErr, err, testcommon.ErrorStringComparer()); diff != "" {
+				t.Errorf("error diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type headscaleTest struct {
+	ms []*headscalev1.Machine
+}
+
+func (h *headscaleTest) MachinesConnected(ctx context.Context) ([]*headscalev1.Machine, error) {
+	return h.ms, nil
+}

--- a/cmd/metal-api/internal/service/vpn-service_test.go
+++ b/cmd/metal-api/internal/service/vpn-service_test.go
@@ -97,6 +97,8 @@ func Test_EvaluateVPNConnected(t *testing.T) {
 			if diff := cmp.Diff(tt.wantErr, err, testcommon.ErrorStringComparer()); diff != "" {
 				t.Errorf("error diff (-want +got):\n%s", diff)
 			}
+
+			mock.AssertExpectations(t)
 		})
 	}
 }

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -891,8 +891,7 @@ func evaluateVPNConnected() error {
 		return err
 	}
 
-	ms := metal.Machines{}
-	err = ds.SearchMachines(&datastore.MachineSearchQuery{AllocationRole: &metal.RoleFirewall}, &ms)
+	ms, err := ds.ListMachines()
 	if err != nil {
 		return err
 	}

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/Masterminds/semver/v3"
@@ -23,9 +24,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	headscalev1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/grpc"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metrics"
 	"github.com/metal-stack/metal-lib/auditing"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
 	"github.com/metal-stack/metal-lib/rest"
 
 	nsq2 "github.com/nsqio/go-nsq"
@@ -888,7 +891,8 @@ func evaluateVPNConnected() error {
 		return err
 	}
 
-	ms, err := ds.ListMachines()
+	ms := metal.Machines{}
+	err = ds.SearchMachines(&datastore.MachineSearchQuery{AllocationRole: &metal.RoleFirewall}, &ms)
 	if err != nil {
 		return err
 	}
@@ -896,7 +900,7 @@ func evaluateVPNConnected() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	connectedMap, err := headscaleClient.MachinesConnected(ctx)
+	headscaleMachines, err := headscaleClient.MachinesConnected(ctx)
 	if err != nil {
 		return err
 	}
@@ -907,8 +911,25 @@ func evaluateVPNConnected() error {
 		if m.Allocation == nil || m.Allocation.VPN == nil {
 			continue
 		}
-		connected := connectedMap[m.ID]
+
+		connected := slices.ContainsFunc(headscaleMachines, func(headscaleMachine *headscalev1.Machine) bool {
+			if headscaleMachine.Name != m.ID {
+				return false
+			}
+
+			if pointer.SafeDeref(headscaleMachine.User).Name != m.Allocation.Project {
+				return false
+			}
+
+			if !headscaleMachine.Online {
+				return false
+			}
+
+			return true
+		})
+
 		if m.Allocation.VPN.Connected == connected {
+			logger.Info("not updating vpn because already up-to-date", "machine", m.ID, "connected", connected)
 			continue
 		}
 
@@ -920,8 +941,10 @@ func evaluateVPNConnected() error {
 			logger.Error("unable to update vpn connected state, continue anyway", "machine", m.ID, "error", err)
 			continue
 		}
+
 		logger.Info("updated vpn connected state", "machine", m.ID, "connected", connected)
 	}
+
 	return errors.Join(errs...)
 }
 


### PR DESCRIPTION
This bug can lead to flapping VPN connections for machines in case a machine was already allocated before but through a different project. Because we used a map implementation, the behavior was pretty much non-deterministic. See this content from headscale as an example:

```
❯ k exec -it headscale-cc9bbbd47-xtlbh -- headscale nodes list | grep 5e214c00-837a-11e9-8000-3cecef23001e                                                                                                                                                                                                                                                                             
608 | 5e214c00-837a-11e9-8000-3cecef23001e | 5e214c00-837a-11e9-8000-3cecef23001e-hery3tdd | [c5ISp]    | [0j/5X] | ef755a9e-37ec-4c70-a67e-f0237e799d4a | , fd7a:115c:a1e0:ab12:2000::18 | false     | 2024-06-07 14:03:49 | 0001-01-01 00:00:00 | online  | no                                                             
564 | 5e214c00-837a-11e9-8000-3cecef23001e | 5e214c00-837a-11e9-8000-3cecef23001e          | [e+RXP]    | [AbKaj] | 1eaa31c0-e092-4a3c-b795-5969b7dfd9c9 | , fd7a:115c:a1e0:ab12:2000::11 | false     | 2024-06-03 12:43:34 | 0001-01-01 00:00:00 | offline | no  
``` 