### PR TITLE
Satisfy new govet errors

### DIFF
--- a/cmd/metal-api/internal/service/machine-service_allocation_test.go
+++ b/cmd/metal-api/internal/service/machine-service_allocation_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -226,7 +227,7 @@ func allocMachine(container *restful.Container, ar v1.MachineAllocateRequest) (v
 	resp := w.Result()
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return v1.MachineResponse{}, fmt.Errorf(w.Body.String())
+		return v1.MachineResponse{}, errors.New(w.Body.String())
 	}
 	var result v1.MachineResponse
 	err = json.NewDecoder(resp.Body).Decode(&result)
@@ -248,7 +249,7 @@ func freeMachine(container *restful.Container, id string) (v1.MachineResponse, e
 	resp := w.Result()
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return v1.MachineResponse{}, fmt.Errorf(w.Body.String())
+		return v1.MachineResponse{}, errors.New(w.Body.String())
 	}
 	var result v1.MachineResponse
 	err = json.NewDecoder(resp.Body).Decode(&result)

--- a/cmd/metal-api/main.go
+++ b/cmd/metal-api/main.go
@@ -957,7 +957,7 @@ func run() error {
 	restful.DefaultContainer.ServiceErrorHandler(func(serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
 		response.Header().Set("Content-Type", "application/json")
 		response.WriteHeader(serviceErr.Code)
-		err := response.WriteAsJson(httperrors.NewHTTPError(serviceErr.Code, fmt.Errorf(serviceErr.Message)))
+		err := response.WriteAsJson(httperrors.NewHTTPError(serviceErr.Code, errors.New(serviceErr.Message)))
 		if err != nil {
 			logger.Error("Failed to send response", "error", err)
 			return


### PR DESCRIPTION
Without this, these errors are reported:

```
cmd/metal-api/main.go:960:83: printf: non-constant format string in call to fmt.Errorf (govet)
                err := response.WriteAsJson(httperrors.NewHTTPError(serviceErr.Code, fmt.Errorf(serviceErr.Message)))
                                                                                                ^
cmd/metal-api/internal/service/machine-service_allocation_test.go:229:43: printf: non-constant format string in call to fmt.Errorf (govet)
                return v1.MachineResponse{}, fmt.Errorf(w.Body.String())
                                                        ^
cmd/metal-api/internal/service/machine-service_allocation_test.go:251:43: printf: non-constant format string in call to fmt.Errorf (govet)
                return v1.MachineResponse{}, fmt.Errorf(w.Body.String())
```