### PR TITLE
Satisfy new linter warnings.

### DIFF
--- a/cmd/metal-api/internal/grpc/boot-service_test.go
+++ b/cmd/metal-api/internal/grpc/boot-service_test.go
@@ -130,8 +130,8 @@ func TestBootService_Register(t *testing.T) {
 					Cpus: []*v1.MachineCPU{
 						{
 							Model:   "Intel Xeon Silver",
-							Cores:   uint32(tt.numcores),
-							Threads: uint32(tt.numcores),
+							Cores:   uint32(tt.numcores), // nolint:gosec
+							Threads: uint32(tt.numcores), // nolint:gosec
 						},
 					},
 					Nics: []*v1.MachineNic{

--- a/cmd/metal-api/internal/service/asn.go
+++ b/cmd/metal-api/internal/service/asn.go
@@ -25,7 +25,7 @@ func acquireASN(ds *datastore.RethinkStore) (*uint32, error) {
 	if err != nil {
 		return nil, err
 	}
-	asn := ASNBase + uint32(i)
+	asn := ASNBase + uint32(i) // nolint:gosec
 	if asn > ASNMax {
 		return nil, fmt.Errorf("unable to calculate asn, got a asn larger than ASNMax: %d > %d", asn, ASNMax)
 	}

--- a/cmd/metal-api/internal/service/partition-service.go
+++ b/cmd/metal-api/internal/service/partition-service.go
@@ -172,7 +172,7 @@ func (r *partitionResource) createPartition(request *restful.Request, response *
 	}
 	prefixLength := uint8(22)
 	if requestPayload.PrivateNetworkPrefixLength != nil {
-		prefixLength = uint8(*requestPayload.PrivateNetworkPrefixLength)
+		prefixLength = uint8(*requestPayload.PrivateNetworkPrefixLength) // nolint:gosec
 		if prefixLength < 16 || prefixLength > 30 {
 			r.sendError(request, response, httperrors.BadRequest(errors.New("private network prefix length is out of range")))
 			return

--- a/cmd/metal-api/internal/service/project-service.go
+++ b/cmd/metal-api/internal/service/project-service.go
@@ -348,8 +348,8 @@ func (r *projectResource) setProjectQuota(project *mdmv1.Project) (*v1.Project, 
 	if qs.Ip == nil {
 		qs.Ip = &v1.Quota{}
 	}
-	machineUsage := int32(len(ms))
-	ipUsage := int32(len(ips))
+	machineUsage := int32(len(ms)) // nolint:gosec
+	ipUsage := int32(len(ips))     // nolint:gosec
 	qs.Machine.Used = &machineUsage
 	qs.Ip.Used = &ipUsage
 


### PR DESCRIPTION
Cherry-picked from the additional-announcable-cidrs branch.