### PR TITLE
Parse SSH public key with correct function.

### DIFF
--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1378,7 +1378,7 @@ func validateAllocationSpec(allocationSpec *machineAllocationSpec) error {
 	}
 
 	for _, pubKey := range allocationSpec.SSHPubKeys {
-		_, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKey))
+		_, err := ssh.ParsePublicKey([]byte(pubKey))
 		if err != nil {
 			return fmt.Errorf("invalid public SSH key: %s", pubKey)
 		}


### PR DESCRIPTION
## Description

When trying to allocate a machine with ECDSA256 algorithm, the metal-api currently errors out. With this PR we will support the main algorithms for public SSH keys.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
