### PR TITLE
If the grpc certificate changed, reboot metal-hammer

### DIFF
--- a/pkg/grpc/wait.go
+++ b/pkg/grpc/wait.go
@@ -2,11 +2,11 @@ package helper
 
 import (
 	"context"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"time"
 
 	v1 "github.com/metal-stack/metal-api/pkg/api/v1"
@@ -26,8 +26,7 @@ func WaitForAllocation(ctx context.Context, log *slog.Logger, service v1.BootSer
 		if err != nil {
 			log.Error("failed waiting for allocation", "retry after", timeout, "error", err)
 
-			var unknownAuthorityError x509.UnknownAuthorityError
-			if errors.Is(err, &unknownAuthorityError) {
+			if strings.Contains(err.Error(), "failed to verify certificate") {
 				return fmt.Errorf("certificate changed, rebooting")
 			}
 

--- a/pkg/grpc/wait.go
+++ b/pkg/grpc/wait.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"time"
 
 	v1 "github.com/metal-stack/metal-api/pkg/api/v1"
@@ -25,6 +26,10 @@ func WaitForAllocation(ctx context.Context, log *slog.Logger, service v1.BootSer
 		if err != nil {
 			log.Error("failed waiting for allocation", "retry after", timeout, "error", err)
 
+			if strings.Contains(err.Error(), "failed to verify certificate") {
+				return fmt.Errorf("certificate changed, rebooting")
+			}
+			
 			time.Sleep(timeout)
 			continue
 		}

--- a/pkg/grpc/wait.go
+++ b/pkg/grpc/wait.go
@@ -2,11 +2,11 @@ package helper
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"strings"
 	"time"
 
 	v1 "github.com/metal-stack/metal-api/pkg/api/v1"
@@ -26,10 +26,11 @@ func WaitForAllocation(ctx context.Context, log *slog.Logger, service v1.BootSer
 		if err != nil {
 			log.Error("failed waiting for allocation", "retry after", timeout, "error", err)
 
-			if strings.Contains(err.Error(), "failed to verify certificate") {
+			var unknownAuthorityError x509.UnknownAuthorityError
+			if errors.Is(err, &unknownAuthorityError) {
 				return fmt.Errorf("certificate changed, rebooting")
 			}
-			
+
 			time.Sleep(timeout)
 			continue
 		}


### PR DESCRIPTION
## Description

During the tests to rotate the ca and all certificates, waiting metal-hammer instances did not reboot. 
Fix this in a ugly manner.

Related: https://github.com/metal-stack/metal-hammer/issues/150

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
