### PR TITLE
Fix swagger spec regarding address family is required.

### DIFF
--- a/cmd/metal-api/internal/service/v1/ip.go
+++ b/cmd/metal-api/internal/service/v1/ip.go
@@ -21,7 +21,7 @@ type IPAllocateRequest struct {
 	Describable
 	IPBase
 	MachineID     *string              `json:"machineid" description:"the machine id this ip should be associated with" optional:"true"`
-	AddressFamily *metal.AddressFamily `json:"addressfamily" description:"the addressfamily to allocate a ip address from the given network, defaults to IPv4" enum:"IPv4|IPv6"`
+	AddressFamily *metal.AddressFamily `json:"addressfamily,omitempty" description:"the addressfamily to allocate a ip address from the given network, defaults to IPv4" enum:"IPv4|IPv6" optional:"true"`
 }
 
 type IPUpdateRequest struct {

--- a/cmd/metal-api/internal/service/v1/network.go
+++ b/cmd/metal-api/internal/service/v1/network.go
@@ -54,7 +54,7 @@ type NetworkAllocateRequest struct {
 	NetworkBase
 	DestinationPrefixes []string                `json:"destinationprefixes" description:"the destination prefixes of this network" optional:"true"`
 	Nat                 *bool                   `json:"nat" description:"if set to true, packets leaving this network get masqueraded behind interface ip" optional:"true"`
-	Length              metal.ChildPrefixLength `json:"length,omitempty" description:"the bit length of the prefix to allocate, defaults to the default child prefix lengths of the parent network" optional:"true"`
+	Length              metal.ChildPrefixLength `json:"length,omitempty" description:"the bit lengths of the prefix to allocate, defaults to the default child prefix lengths of the parent network" optional:"true"`
 	ParentNetworkID     *string                 `json:"parentnetworkid" description:"the parent network from which this network should be allocated"`
 	AddressFamily       *metal.AddressFamily    `json:"addressfamily,omitempty" description:"the addressfamily to allocate a child network. If not specified, the child network inherits the addressfamilies from the parent." enum:"IPv4|IPv6" optional:"true"`
 }

--- a/cmd/metal-api/internal/service/v1/network.go
+++ b/cmd/metal-api/internal/service/v1/network.go
@@ -54,9 +54,9 @@ type NetworkAllocateRequest struct {
 	NetworkBase
 	DestinationPrefixes []string                `json:"destinationprefixes" description:"the destination prefixes of this network" optional:"true"`
 	Nat                 *bool                   `json:"nat" description:"if set to true, packets leaving this network get masqueraded behind interface ip" optional:"true"`
-	Length              metal.ChildPrefixLength `json:"length" description:"the bitlen of the prefix to allocate, defaults to defaultchildprefixlength of super prefix"`
+	Length              metal.ChildPrefixLength `json:"length,omitempty" description:"the bit length of the prefix to allocate, defaults to the default child prefix lengths of the parent network" optional:"true"`
 	ParentNetworkID     *string                 `json:"parentnetworkid" description:"the parent network from which this network should be allocated"`
-	AddressFamily       *metal.AddressFamily    `json:"addressfamily" description:"the addressfamily to allocate a child network defaults. If not specified, the child network inherits the addressfamilies from the parent." enum:"IPv4|IPv6"`
+	AddressFamily       *metal.AddressFamily    `json:"addressfamily,omitempty" description:"the addressfamily to allocate a child network. If not specified, the child network inherits the addressfamilies from the parent." enum:"IPv4|IPv6" optional:"true"`
 }
 
 // NetworkFindRequest is used to find a Network with different criteria.

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -3725,7 +3725,7 @@
           "additionalProperties": {
             "type": "integer"
           },
-          "description": "the bit length of the prefix to allocate, defaults to the default child prefix lengths of the parent network",
+          "description": "the bit lengths of the prefix to allocate, defaults to the default child prefix lengths of the parent network",
           "type": "object"
         },
         "name": {

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -1611,7 +1611,6 @@
         }
       },
       "required": [
-        "addressfamily",
         "networkid",
         "projectid",
         "type"

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -3696,7 +3696,7 @@
     "v1.NetworkAllocateRequest": {
       "properties": {
         "addressfamily": {
-          "description": "the addressfamily to allocate a child network defaults. If not specified, the child network inherits the addressfamilies from the parent.",
+          "description": "the addressfamily to allocate a child network. If not specified, the child network inherits the addressfamilies from the parent.",
           "enum": [
             "IPv4",
             "IPv6"
@@ -3725,7 +3725,7 @@
           "additionalProperties": {
             "type": "integer"
           },
-          "description": "the bitlen of the prefix to allocate, defaults to defaultchildprefixlength of super prefix",
+          "description": "the bit length of the prefix to allocate, defaults to the default child prefix lengths of the parent network",
           "type": "object"
         },
         "name": {
@@ -3754,8 +3754,6 @@
         }
       },
       "required": [
-        "addressfamily",
-        "length",
         "parentnetworkid"
       ]
     },


### PR DESCRIPTION
## Description

Python clients are failing when they leave out the address family field.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
