### PR TITLE
Remove unnecessary parent network ID field from network allocation.

### DIFF
--- a/cmd/metal-api/internal/service/network-service.go
+++ b/cmd/metal-api/internal/service/network-service.go
@@ -590,9 +590,8 @@ func (r *networkResource) allocateNetwork(request *restful.Request, response *re
 	)
 
 	err = r.ds.FindNetwork(&datastore.NetworkSearchQuery{
-		PartitionID:     &partition.ID,
-		PrivateSuper:    pointer.Pointer(true),
-		ParentNetworkID: requestPayload.ParentNetworkID,
+		PartitionID:  &partition.ID,
+		PrivateSuper: pointer.Pointer(true),
 	}, &superNetwork)
 	if err != nil {
 		r.sendError(request, response, defaultError(err))

--- a/cmd/metal-api/internal/service/v1/network.go
+++ b/cmd/metal-api/internal/service/v1/network.go
@@ -55,7 +55,6 @@ type NetworkAllocateRequest struct {
 	DestinationPrefixes []string                `json:"destinationprefixes" description:"the destination prefixes of this network" optional:"true"`
 	Nat                 *bool                   `json:"nat" description:"if set to true, packets leaving this network get masqueraded behind interface ip" optional:"true"`
 	Length              metal.ChildPrefixLength `json:"length,omitempty" description:"the bit lengths of the prefix to allocate, defaults to the default child prefix lengths of the parent network" optional:"true"`
-	ParentNetworkID     *string                 `json:"parentnetworkid" description:"the parent network from which this network should be allocated"`
 	AddressFamily       *metal.AddressFamily    `json:"addressfamily,omitempty" description:"the addressfamily to allocate a child network. If not specified, the child network inherits the addressfamilies from the parent." enum:"IPv4|IPv6" optional:"true"`
 }
 

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -3736,10 +3736,6 @@
           "description": "if set to true, packets leaving this network get masqueraded behind interface ip",
           "type": "boolean"
         },
-        "parentnetworkid": {
-          "description": "the parent network from which this network should be allocated",
-          "type": "string"
-        },
         "partitionid": {
           "description": "the partition this network belongs to",
           "type": "string"
@@ -3752,10 +3748,7 @@
           "description": "marks a network as shareable.",
           "type": "boolean"
         }
-      },
-      "required": [
-        "parentnetworkid"
-      ]
+      }
     },
     "v1.NetworkBase": {
       "properties": {


### PR DESCRIPTION
## Description

I think this is unnecessary because so far a super network never has a parent? I think this field would imply nested super networks? Was added in #549.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
