### PR TITLE
Ignore delayed buffered phoned home events during machine reclaim

### DIFF
--- a/cmd/metal-api/internal/fsm/events.go
+++ b/cmd/metal-api/internal/fsm/events.go
@@ -88,6 +88,10 @@ func Events() fsm.Events {
 			Src: []string{
 				states.PlannedReboot.String(),
 				states.PhonedHome.String(),
+				states.PXEBooting.String(),
+				states.Preparing.String(),
+				states.Registering.String(),
+				states.Waiting.String(),
 			},
 			Dst: SelfTransitionState,
 		},

--- a/cmd/metal-api/internal/fsm/states/alive.go
+++ b/cmd/metal-api/internal/fsm/states/alive.go
@@ -2,23 +2,21 @@ package states
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type AliveState struct {
-	log       *slog.Logger
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newAlive(c *StateConfig) *AliveState {
 	return &AliveState{
-		log:       c.Log,
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/booting-new-kernel.go
+++ b/cmd/metal-api/internal/fsm/states/booting-new-kernel.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type BootingNewKernelState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newBootingNewKernel(c *StateConfig) *BootingNewKernelState {
 	return &BootingNewKernelState{
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/crashed.go
+++ b/cmd/metal-api/internal/fsm/states/crashed.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type CrashState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newCrash(c *StateConfig) *CrashState {
 	return &CrashState{
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/initial.go
+++ b/cmd/metal-api/internal/fsm/states/initial.go
@@ -5,18 +5,19 @@ import (
 	"fmt"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type InitialState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newInitial(c *StateConfig) *InitialState {
 	return &InitialState{
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/installing.go
+++ b/cmd/metal-api/internal/fsm/states/installing.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type InstallingState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newInstalling(c *StateConfig) *InstallingState {
 	return &InstallingState{
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/machine-reclaim.go
+++ b/cmd/metal-api/internal/fsm/states/machine-reclaim.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type MachineReclaimState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newMachineReclaim(c *StateConfig) *MachineReclaimState {
 	return &MachineReclaimState{
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/phoned-home.go
+++ b/cmd/metal-api/internal/fsm/states/phoned-home.go
@@ -2,23 +2,21 @@ package states
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type PhonedHomeState struct {
-	log       *slog.Logger
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newPhonedHome(c *StateConfig) *PhonedHomeState {
 	return &PhonedHomeState{
-		log:       c.Log,
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/phoned-home.go
+++ b/cmd/metal-api/internal/fsm/states/phoned-home.go
@@ -3,14 +3,10 @@ package states
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"github.com/looplab/fsm"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
-
-// failedMachineReclaimThreshold is the duration after which the machine reclaim is assumed to have failed.
-const failedMachineReclaimThreshold = 5 * time.Minute
 
 type PhonedHomeState struct {
 	log       *slog.Logger

--- a/cmd/metal-api/internal/fsm/states/planned-reboot.go
+++ b/cmd/metal-api/internal/fsm/states/planned-reboot.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type PlannedRebootState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
+	*FSMState
 }
 
 func newPlannedReboot(c *StateConfig) *PlannedRebootState {
 	return &PlannedRebootState{
-		container: c.Container,
-		event:     c.Event,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 

--- a/cmd/metal-api/internal/fsm/states/preparing.go
+++ b/cmd/metal-api/internal/fsm/states/preparing.go
@@ -2,35 +2,26 @@ package states
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type PreparingState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
-	log       *slog.Logger
+	*FSMState
 }
 
 func newPreparing(c *StateConfig) *PreparingState {
 	return &PreparingState{
-		container: c.Container,
-		event:     c.Event,
-		log:       c.Log,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 
 func (p *PreparingState) OnTransition(ctx context.Context, e *fsm.Event) {
-	if e.Event == metal.ProvisioningEventPhonedHome.String() {
-		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
-			p.log.Debug("swallowing delayed phoned home event after preparing event was already received", "id", p.container.ID)
-			return
-		}
-	}
-
+	p.swallowBufferedPhonedHome(e)
 	p.container.FailedMachineReclaim = false
-
 	appendEventToContainer(p.event, p.container)
 }

--- a/cmd/metal-api/internal/fsm/states/preparing.go
+++ b/cmd/metal-api/internal/fsm/states/preparing.go
@@ -21,7 +21,9 @@ func newPreparing(c *StateConfig) *PreparingState {
 }
 
 func (p *PreparingState) OnTransition(ctx context.Context, e *fsm.Event) {
-	p.swallowBufferedPhonedHome(e)
+	if p.swallowBufferedPhonedHome(e) {
+		return
+	}
 	p.container.FailedMachineReclaim = false
 	appendEventToContainer(p.event, p.container)
 }

--- a/cmd/metal-api/internal/fsm/states/preparing.go
+++ b/cmd/metal-api/internal/fsm/states/preparing.go
@@ -2,6 +2,7 @@ package states
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/looplab/fsm"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
@@ -10,16 +11,25 @@ import (
 type PreparingState struct {
 	container *metal.ProvisioningEventContainer
 	event     *metal.ProvisioningEvent
+	log       *slog.Logger
 }
 
 func newPreparing(c *StateConfig) *PreparingState {
 	return &PreparingState{
 		container: c.Container,
 		event:     c.Event,
+		log:       c.Log,
 	}
 }
 
 func (p *PreparingState) OnTransition(ctx context.Context, e *fsm.Event) {
+	if e.Event == metal.ProvisioningEventPhonedHome.String() {
+		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
+			p.log.Debug("swallowing delayed phoned home event after preparing event was already received", "id", p.container.ID)
+			return
+		}
+	}
+
 	p.container.FailedMachineReclaim = false
 
 	appendEventToContainer(p.event, p.container)

--- a/cmd/metal-api/internal/fsm/states/pxe-booting.go
+++ b/cmd/metal-api/internal/fsm/states/pxe-booting.go
@@ -2,6 +2,7 @@ package states
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/looplab/fsm"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
@@ -10,16 +11,25 @@ import (
 type PXEBootingState struct {
 	container *metal.ProvisioningEventContainer
 	event     *metal.ProvisioningEvent
+	log       *slog.Logger
 }
 
 func newPXEBooting(c *StateConfig) *PXEBootingState {
 	return &PXEBootingState{
 		container: c.Container,
 		event:     c.Event,
+		log:       c.Log,
 	}
 }
 
 func (p *PXEBootingState) OnTransition(ctx context.Context, e *fsm.Event) {
+	if e.Event == metal.ProvisioningEventPhonedHome.String() {
+		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
+			p.log.Debug("swallowing delayed phoned home event after pxe booting event was already received", "id", p.container.ID)
+			return
+		}
+	}
+
 	p.container.FailedMachineReclaim = false
 
 	if e.Src == PXEBooting.String() {

--- a/cmd/metal-api/internal/fsm/states/pxe-booting.go
+++ b/cmd/metal-api/internal/fsm/states/pxe-booting.go
@@ -21,7 +21,9 @@ func newPXEBooting(c *StateConfig) *PXEBootingState {
 }
 
 func (p *PXEBootingState) OnTransition(ctx context.Context, e *fsm.Event) {
-	p.swallowBufferedPhonedHome(e)
+	if p.swallowBufferedPhonedHome(e) {
+		return
+	}
 	p.container.FailedMachineReclaim = false
 
 	if e.Src == PXEBooting.String() {

--- a/cmd/metal-api/internal/fsm/states/pxe-booting.go
+++ b/cmd/metal-api/internal/fsm/states/pxe-booting.go
@@ -2,34 +2,26 @@ package states
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type PXEBootingState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
-	log       *slog.Logger
+	*FSMState
 }
 
 func newPXEBooting(c *StateConfig) *PXEBootingState {
 	return &PXEBootingState{
-		container: c.Container,
-		event:     c.Event,
-		log:       c.Log,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 
 func (p *PXEBootingState) OnTransition(ctx context.Context, e *fsm.Event) {
-	if e.Event == metal.ProvisioningEventPhonedHome.String() {
-		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
-			p.log.Debug("swallowing delayed phoned home event after pxe booting event was already received", "id", p.container.ID)
-			return
-		}
-	}
-
+	p.swallowBufferedPhonedHome(e)
 	p.container.FailedMachineReclaim = false
 
 	if e.Src == PXEBooting.String() {

--- a/cmd/metal-api/internal/fsm/states/registering.go
+++ b/cmd/metal-api/internal/fsm/states/registering.go
@@ -2,6 +2,7 @@ package states
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/looplab/fsm"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
@@ -10,15 +11,24 @@ import (
 type RegisteringState struct {
 	container *metal.ProvisioningEventContainer
 	event     *metal.ProvisioningEvent
+	log       *slog.Logger
 }
 
 func newRegistering(c *StateConfig) *RegisteringState {
 	return &RegisteringState{
 		container: c.Container,
 		event:     c.Event,
+		log:       c.Log,
 	}
 }
 
 func (p *RegisteringState) OnTransition(ctx context.Context, e *fsm.Event) {
+	if e.Event == metal.ProvisioningEventPhonedHome.String() {
+		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
+			p.log.Debug("swallowing delayed phoned home event after registering event was already received", "id", p.container.ID)
+			return
+		}
+	}
+
 	appendEventToContainer(p.event, p.container)
 }

--- a/cmd/metal-api/internal/fsm/states/registering.go
+++ b/cmd/metal-api/internal/fsm/states/registering.go
@@ -2,33 +2,25 @@ package states
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type RegisteringState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
-	log       *slog.Logger
+	*FSMState
 }
 
 func newRegistering(c *StateConfig) *RegisteringState {
 	return &RegisteringState{
-		container: c.Container,
-		event:     c.Event,
-		log:       c.Log,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 
 func (p *RegisteringState) OnTransition(ctx context.Context, e *fsm.Event) {
-	if e.Event == metal.ProvisioningEventPhonedHome.String() {
-		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
-			p.log.Debug("swallowing delayed phoned home event after registering event was already received", "id", p.container.ID)
-			return
-		}
-	}
-
+	p.swallowBufferedPhonedHome(e)
 	appendEventToContainer(p.event, p.container)
 }

--- a/cmd/metal-api/internal/fsm/states/registering.go
+++ b/cmd/metal-api/internal/fsm/states/registering.go
@@ -21,6 +21,8 @@ func newRegistering(c *StateConfig) *RegisteringState {
 }
 
 func (p *RegisteringState) OnTransition(ctx context.Context, e *fsm.Event) {
-	p.swallowBufferedPhonedHome(e)
+	if p.swallowBufferedPhonedHome(e) {
+		return
+	}
 	appendEventToContainer(p.event, p.container)
 }

--- a/cmd/metal-api/internal/fsm/states/states.go
+++ b/cmd/metal-api/internal/fsm/states/states.go
@@ -3,6 +3,7 @@ package states
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/looplab/fsm"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
@@ -21,6 +22,11 @@ const (
 	PhonedHome       stateType = "State Phoned Home"
 	PlannedReboot    stateType = "State Planned Reboot"
 	MachineReclaim   stateType = "State Machine Reclaim"
+
+	// failedMachineReclaimThreshold is the duration after which the machine reclaim is assumed to have failed.
+	failedMachineReclaimThreshold = 5 * time.Minute
+	// swallowBufferedPhonedHomeThreshold is the duration after which we don't expect any delayed phoned home events to occur.
+	swallowBufferedPhonedHomeThreshold = 5 * time.Minute
 )
 
 type FSMState interface {

--- a/cmd/metal-api/internal/fsm/states/states.go
+++ b/cmd/metal-api/internal/fsm/states/states.go
@@ -88,11 +88,12 @@ func updateTimeAndLiveliness(event *metal.ProvisioningEvent, container *metal.Pr
 	container.Liveliness = metal.MachineLivelinessAlive
 }
 
-func (s *FSMState) swallowBufferedPhonedHome(e *fsm.Event) {
+func (s *FSMState) swallowBufferedPhonedHome(e *fsm.Event) bool {
 	if e.Event == metal.ProvisioningEventPhonedHome.String() {
 		if s.container.LastEventTime != nil && s.event.Time.Sub(*s.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
 			s.log.Debug("swallowing delayed phoned home event", "current event", s.event, "id", s.container.ID)
-			return
+			return true
 		}
 	}
+	return false
 }

--- a/cmd/metal-api/internal/fsm/states/waiting.go
+++ b/cmd/metal-api/internal/fsm/states/waiting.go
@@ -2,32 +2,25 @@ package states
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/looplab/fsm"
-	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
 )
 
 type WaitingState struct {
-	container *metal.ProvisioningEventContainer
-	event     *metal.ProvisioningEvent
-	log       *slog.Logger
+	*FSMState
 }
 
 func newWaiting(c *StateConfig) *WaitingState {
 	return &WaitingState{
-		container: c.Container,
-		event:     c.Event,
-		log:       c.Log,
+		FSMState: &FSMState{
+			container: c.Container,
+			event:     c.Event,
+			log:       c.Log,
+		},
 	}
 }
 
 func (p *WaitingState) OnTransition(ctx context.Context, e *fsm.Event) {
-	if e.Event == metal.ProvisioningEventPhonedHome.String() {
-		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
-			p.log.Debug("swallowing delayed phoned home event after waiting event was already received", "id", p.container.ID)
-			return
-		}
-	}
+	p.swallowBufferedPhonedHome(e)
 	appendEventToContainer(p.event, p.container)
 }

--- a/cmd/metal-api/internal/fsm/states/waiting.go
+++ b/cmd/metal-api/internal/fsm/states/waiting.go
@@ -21,6 +21,8 @@ func newWaiting(c *StateConfig) *WaitingState {
 }
 
 func (p *WaitingState) OnTransition(ctx context.Context, e *fsm.Event) {
-	p.swallowBufferedPhonedHome(e)
+	if p.swallowBufferedPhonedHome(e) {
+		return
+	}
 	appendEventToContainer(p.event, p.container)
 }

--- a/cmd/metal-api/internal/fsm/states/waiting.go
+++ b/cmd/metal-api/internal/fsm/states/waiting.go
@@ -2,6 +2,7 @@ package states
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/looplab/fsm"
 	"github.com/metal-stack/metal-api/cmd/metal-api/internal/metal"
@@ -10,15 +11,23 @@ import (
 type WaitingState struct {
 	container *metal.ProvisioningEventContainer
 	event     *metal.ProvisioningEvent
+	log       *slog.Logger
 }
 
 func newWaiting(c *StateConfig) *WaitingState {
 	return &WaitingState{
 		container: c.Container,
 		event:     c.Event,
+		log:       c.Log,
 	}
 }
 
 func (p *WaitingState) OnTransition(ctx context.Context, e *fsm.Event) {
+	if e.Event == metal.ProvisioningEventPhonedHome.String() {
+		if p.container.LastEventTime != nil && p.event.Time.Sub(*p.container.LastEventTime) < swallowBufferedPhonedHomeThreshold {
+			p.log.Debug("swallowing delayed phoned home event after waiting event was already received", "id", p.container.ID)
+			return
+		}
+	}
 	appendEventToContainer(p.event, p.container)
 }


### PR DESCRIPTION
## Description

Closes https://github.com/metal-stack/metal-api/issues/630.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
