### PR TITLE
Add new network properties to machineNetwork

### DIFF
--- a/cmd/metal-api/internal/metal/machine.go
+++ b/cmd/metal-api/internal/metal/machine.go
@@ -378,17 +378,20 @@ func (ms Machines) WithRole(role Role) Machines {
 
 // MachineNetwork stores the Network details of the machine
 type MachineNetwork struct {
-	NetworkID           string   `rethinkdb:"networkid" json:"networkid"`
-	Prefixes            []string `rethinkdb:"prefixes" json:"prefixes"`
-	IPs                 []string `rethinkdb:"ips" json:"ips"`
-	DestinationPrefixes []string `rethinkdb:"destinationprefixes" json:"destinationprefixes"`
-	Vrf                 uint     `rethinkdb:"vrf" json:"vrf"`
-	PrivatePrimary      bool     `rethinkdb:"privateprimary" json:"privateprimary"`
-	Private             bool     `rethinkdb:"private" json:"private"`
-	ASN                 uint32   `rethinkdb:"asn" json:"asn"`
-	Nat                 bool     `rethinkdb:"nat" json:"nat"`
-	Underlay            bool     `rethinkdb:"underlay" json:"underlay"`
-	Shared              bool     `rethinkdb:"shared" json:"shared"`
+	NetworkID           string        `rethinkdb:"networkid" json:"networkid"`
+	Prefixes            []string      `rethinkdb:"prefixes" json:"prefixes"`
+	IPs                 []string      `rethinkdb:"ips" json:"ips"`
+	DestinationPrefixes []string      `rethinkdb:"destinationprefixes" json:"destinationprefixes"`
+	Vrf                 uint          `rethinkdb:"vrf" json:"vrf"`
+	PrivatePrimary      bool          `rethinkdb:"privateprimary" json:"privateprimary"`
+	Private             bool          `rethinkdb:"private" json:"private"`
+	ASN                 uint32        `rethinkdb:"asn" json:"asn"`
+	Nat                 bool          `rethinkdb:"nat" json:"nat"`
+	Underlay            bool          `rethinkdb:"underlay" json:"underlay"`
+	Shared              bool          `rethinkdb:"shared" json:"shared"`
+	ProjectID           string        `rethinkdb:"projectid" json:"projectid"`
+	NetworkTypeV2       NetworkTypeV2 `rethinkdb:"networktype" json:"networktype"`
+	NATTypeV2           NATType       `rethinkdb:"nattype" json:"nattype"`
 }
 
 // NetworkType represents the type of a network

--- a/cmd/metal-api/internal/metal/machine.go
+++ b/cmd/metal-api/internal/metal/machine.go
@@ -378,20 +378,23 @@ func (ms Machines) WithRole(role Role) Machines {
 
 // MachineNetwork stores the Network details of the machine
 type MachineNetwork struct {
-	NetworkID           string        `rethinkdb:"networkid" json:"networkid"`
-	Prefixes            []string      `rethinkdb:"prefixes" json:"prefixes"`
-	IPs                 []string      `rethinkdb:"ips" json:"ips"`
-	DestinationPrefixes []string      `rethinkdb:"destinationprefixes" json:"destinationprefixes"`
-	Vrf                 uint          `rethinkdb:"vrf" json:"vrf"`
-	PrivatePrimary      bool          `rethinkdb:"privateprimary" json:"privateprimary"`
-	Private             bool          `rethinkdb:"private" json:"private"`
-	ASN                 uint32        `rethinkdb:"asn" json:"asn"`
-	Nat                 bool          `rethinkdb:"nat" json:"nat"`
-	Underlay            bool          `rethinkdb:"underlay" json:"underlay"`
-	Shared              bool          `rethinkdb:"shared" json:"shared"`
-	ProjectID           string        `rethinkdb:"projectid" json:"projectid"`
-	NetworkTypeV2       NetworkTypeV2 `rethinkdb:"networktype" json:"networktype"`
-	NATTypeV2           NATType       `rethinkdb:"nattype" json:"nattype"`
+	NetworkID           string   `rethinkdb:"networkid" json:"networkid"`
+	Prefixes            []string `rethinkdb:"prefixes" json:"prefixes"`
+	IPs                 []string `rethinkdb:"ips" json:"ips"`
+	DestinationPrefixes []string `rethinkdb:"destinationprefixes" json:"destinationprefixes"`
+	Vrf                 uint     `rethinkdb:"vrf" json:"vrf"`
+	PrivatePrimary      bool     `rethinkdb:"privateprimary" json:"privateprimary"`
+	Private             bool     `rethinkdb:"private" json:"private"`
+	ASN                 uint32   `rethinkdb:"asn" json:"asn"`
+	Nat                 bool     `rethinkdb:"nat" json:"nat"`
+	Underlay            bool     `rethinkdb:"underlay" json:"underlay"`
+	Shared              bool     `rethinkdb:"shared" json:"shared"`
+	// The following 3 properties are persisted only for new machines, existing machine allocations will be updated
+	// This required to enable forward compatibility to apiv2
+	// TODO carry over these properties to metal-apiserver as well
+	ProjectID     string        `rethinkdb:"projectid" json:"projectid"`
+	NetworkTypeV2 NetworkTypeV2 `rethinkdb:"networktype" json:"networktype"`
+	NATTypeV2     NATType       `rethinkdb:"nattype" json:"nattype"`
 }
 
 // NetworkType represents the type of a network

--- a/cmd/metal-api/internal/service/machine-service.go
+++ b/cmd/metal-api/internal/service/machine-service.go
@@ -1714,6 +1714,9 @@ func makeMachineNetwork(ctx context.Context, ds *datastore.RethinkStore, ipamer 
 		Underlay:            n.networkType.Underlay,
 		Nat:                 n.network.Nat,
 		Vrf:                 n.network.Vrf,
+		ProjectID:           n.network.ProjectID,
+		NetworkTypeV2:       pointer.SafeDeref(n.network.NetworkType),
+		NATTypeV2:           pointer.SafeDeref(n.network.NATType),
 	}
 
 	return &machineNetwork, nil

--- a/cmd/metal-api/internal/service/v1/machine.go
+++ b/cmd/metal-api/internal/service/v1/machine.go
@@ -82,6 +82,14 @@ type MachineNetwork struct {
 	//
 	// Deprecated: can be removed once old machine images without NetworkType are not supported anymore
 	Underlay bool `json:"underlay" description:"if set to true, this network can be used for underlay communication"`
+
+	// The following type are used to get forward compatibility with apiv2
+	// ProjectID is required to detect the new networktype
+	ProjectID string `json:"projectid" description:"project of this network, empty string if not project scoped"`
+	// NetworkTypeV2 is the apiv2 networktype
+	NetworkTypeV2 metal.NetworkTypeV2 `json:"networktypev2"`
+	// NatTypeV2 is the apiv2 nattype
+	NATTypeV2 metal.NATType `json:"nattypev2"`
 }
 
 type MachineHardwareBase struct {
@@ -555,6 +563,10 @@ func NewMachineResponse(m *metal.Machine, s *metal.Size, p *metal.Partition, i *
 				// FIXME: Both following fields are deprecated and for backward compatibility reasons only
 				Private:  nt.Private,
 				Underlay: nt.Underlay,
+
+				ProjectID:     nw.ProjectID,
+				NetworkTypeV2: nw.NetworkTypeV2,
+				NATTypeV2:     nw.NATTypeV2,
 			}
 			networks = append(networks, network)
 		}

--- a/cmd/metal-api/internal/service/v1/network.go
+++ b/cmd/metal-api/internal/service/v1/network.go
@@ -25,6 +25,8 @@ type NetworkImmutable struct {
 	VrfShared                  *bool                   `json:"vrfshared" description:"if set to true, given vrf can be used by multiple networks, which is sometimes useful for network partitioning (default: false)" optional:"true"`
 	ParentNetworkID            *string                 `json:"parentnetworkid" description:"the id of the parent network" optional:"true"`
 	AdditionalAnnouncableCIDRs []string                `json:"additionalAnnouncableCIDRs,omitempty" description:"list of cidrs which are added to the route maps per tenant private network, these are typically pod- and service cidrs, can only be set for private super networks"`
+	NetworkType                *metal.NetworkTypeV2    `json:"networktype" description:"apiv2 network type"`
+	NATType                    *metal.NATType          `json:"nattype" description:"apiv2 nat type"`
 }
 
 type NetworkConsumption struct {
@@ -133,6 +135,8 @@ func NewNetworkResponse(network *metal.Network, consumption *NetworkConsumption)
 			Vrf:                        &network.Vrf,
 			ParentNetworkID:            parentNetworkID,
 			AdditionalAnnouncableCIDRs: network.AdditionalAnnouncableCIDRs,
+			NetworkType:                network.NetworkType,
+			NATType:                    network.NATType,
 		},
 		Consumption: *consumption,
 		Timestamps: Timestamps{

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -3844,6 +3844,14 @@
           "description": "if set to true, packets leaving this ipv4 network get masqueraded behind interface ip",
           "type": "boolean"
         },
+        "nattype": {
+          "description": "apiv2 nat type",
+          "type": "string"
+        },
+        "networktype": {
+          "description": "apiv2 network type",
+          "type": "string"
+        },
         "parentnetworkid": {
           "description": "the id of the parent network",
           "type": "string"
@@ -3889,6 +3897,8 @@
         "destinationprefixes",
         "id",
         "nat",
+        "nattype",
+        "networktype",
         "prefixes",
         "privatesuper",
         "underlay"
@@ -3979,6 +3989,14 @@
           "description": "if set to true, packets leaving this ipv4 network get masqueraded behind interface ip",
           "type": "boolean"
         },
+        "nattype": {
+          "description": "apiv2 nat type",
+          "type": "string"
+        },
+        "networktype": {
+          "description": "apiv2 network type",
+          "type": "string"
+        },
         "parentnetworkid": {
           "description": "the id of the parent network",
           "type": "string"
@@ -4011,6 +4029,8 @@
       "required": [
         "destinationprefixes",
         "nat",
+        "nattype",
+        "networktype",
         "prefixes",
         "privatesuper",
         "underlay"
@@ -4078,6 +4098,14 @@
           "description": "if set to true, packets leaving this ipv4 network get masqueraded behind interface ip",
           "type": "boolean"
         },
+        "nattype": {
+          "description": "apiv2 nat type",
+          "type": "string"
+        },
+        "networktype": {
+          "description": "apiv2 network type",
+          "type": "string"
+        },
         "parentnetworkid": {
           "description": "the id of the parent network",
           "type": "string"
@@ -4128,6 +4156,8 @@
         "destinationprefixes",
         "id",
         "nat",
+        "nattype",
+        "networktype",
         "prefixes",
         "privatesuper",
         "underlay",

--- a/spec/metal-api.json
+++ b/spec/metal-api.json
@@ -3258,12 +3258,18 @@
           "description": "if set to true, packets leaving this network get masqueraded behind interface ip",
           "type": "boolean"
         },
+        "nattypev2": {
+          "type": "string"
+        },
         "networkid": {
           "description": "the networkID of the allocated machine in this vrf",
           "type": "string"
         },
         "networktype": {
           "description": "the network type, types can be looked up in the network package of metal-lib",
+          "type": "string"
+        },
+        "networktypev2": {
           "type": "string"
         },
         "prefixes": {
@@ -3276,6 +3282,10 @@
         "private": {
           "description": "indicates whether this network is the private network of this machine",
           "type": "boolean"
+        },
+        "projectid": {
+          "description": "project of this network, empty string if not project scoped",
+          "type": "string"
         },
         "underlay": {
           "description": "if set to true, this network can be used for underlay communication",
@@ -3292,10 +3302,13 @@
         "destinationprefixes",
         "ips",
         "nat",
+        "nattypev2",
         "networkid",
         "networktype",
+        "networktypev2",
         "prefixes",
         "private",
+        "projectid",
         "underlay",
         "vrf"
       ]


### PR DESCRIPTION
## Description

In Order to be able to gradually migrate to new apiv2 consumers, also put new networktypes into the machineNetwork into the Allocation.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
